### PR TITLE
AE-869 - when et is deleted then korvattu_energiatodistus_id is also set to null. 

### DIFF
--- a/etp-backend/src/main/sql/solita/etp/db/energiatodistus.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/energiatodistus.sql
@@ -1,6 +1,8 @@
 
 -- name: delete-energiatodistus-luonnos!
-update energiatodistus set tila_id = et_tilat.poistettu
+update energiatodistus set
+  tila_id = et_tilat.poistettu,
+  korvattu_energiatodistus_id = null
 from et_tilat
 where tila_id = et_tilat.luonnos and id = :id
 


### PR DESCRIPTION
Deleted et cannot replace anything.