### PR TITLE
Permit valvoja to post comments on replaced ETs

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus.clj
@@ -315,6 +315,9 @@
                  [:pt$rakennustunnus
                   :korvattu-energiatodistus-id
                   :kommentti])
+    [:replaced :paakayttaja _]
+    (select-keys energiatodistus-update
+                 [:kommentti])
     :else (exception/throw-forbidden!
             (str "Role: " rooli
                  " is not allowed to update energiatodistus " id


### PR DESCRIPTION
This addresses bug
AE-748 Kommentin lisääminen korvatulle energiatodistukselle ei toimi