### PR TITLE
Isolate libreoffice invocations from each other

### DIFF
--- a/etp-backend/src/main/clj/solita/common/libreoffice.clj
+++ b/etp-backend/src/main/clj/solita/common/libreoffice.clj
@@ -1,0 +1,50 @@
+(ns solita.common.libreoffice
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell])
+  (:import (java.io IOException)
+           (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute)))
+
+;; Recursive delete from https://gist.github.com/olieidel/c551a911a4798312e4ef42a584677397
+(defn rm [file]
+  (when (.isDirectory file)
+    (doseq [file-in-dir (.listFiles file)]
+      (rm file-in-dir)))
+  (io/delete-file file))
+
+(defn rm-path [path]
+  (let [file (.toFile path)]
+    (if (.exists file)
+      (rm (.toFile path)))))
+
+(defn config-path []
+  ;; The configuration can likely be overridden to be somewhere else,
+  ;; but this should be a reasonably safe assumption.
+  (str (System/getenv "HOME") "/.config/libreoffice/4"))
+
+(defn make-tmpdir []
+  (let [attrs (make-array FileAttribute 0)]
+    (Files/createTempDirectory "libreoffice-user" attrs)))
+
+(defn populate-tmpdir [path]
+  (let [src-dir (config-path)
+        cmd ["cp" "-r" src-dir (str path "/config")]
+        result (apply shell/sh cmd)]
+    (when (not (= 0 (:exit result)))
+      (throw (IOException. (:err result))))))
+
+(defn exec-lo [tmpdir args]
+  (let [dirparam (str "-env:UserInstallation=file://" tmpdir "/config")]
+    (apply shell/sh
+           "libreoffice"
+           dirparam
+           "--headless"
+           args)))
+
+(defn run-with-args [& args]
+  (let [tmpdir (make-tmpdir)]
+    (try
+      (populate-tmpdir tmpdir)
+      (exec-lo tmpdir args)
+      (finally (rm-path tmpdir)))))
+

--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_pdf.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_pdf.clj
@@ -1,12 +1,12 @@
 (ns solita.etp.service.energiatodistus-pdf
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
-            [clojure.java.shell :as shell]
             [clojure.tools.logging :as log]
             [puumerkki.pdf :as puumerkki]
             [solita.etp.exception :as exception]
             [solita.common.xlsx :as xlsx]
             [solita.common.certificates :as certificates]
+            [solita.common.libreoffice :as libreoffice]
             [solita.etp.service.energiatodistus :as energiatodistus-service]
             [solita.etp.service.complete-energiatodistus :as complete-energiatodistus-service]
             [solita.etp.service.file :as file-service]
@@ -606,13 +606,12 @@
         filename (.getName file)
         dir (.getParent file)
         result-pdf (str/replace path #".xlsx$" ".pdf")
-        {:keys [exit err] :as sh-result} (shell/sh "libreoffice"
-                                                   "--headless"
-                                                   "--convert-to"
-                                                   "pdf"
-                                                   filename
-                                                   :dir
-                                                   dir)]
+        {:keys [exit err] :as sh-result} (libreoffice/run-with-args
+                                          "--convert-to"
+                                          "pdf"
+                                          filename
+                                          :dir
+                                          dir)]
     (if (and (zero? exit) (str/blank? err) (.exists (io/as-file result-pdf)))
       result-pdf
       (throw (ex-info "XLSX to PDF conversion failed"


### PR DESCRIPTION
This addresses AE-1053

It seems to suffice that an unique UserInstallation parameter is used
for each invocation. The parameter does not actually have much to do
with the installation location, but it tells where the settings of the
user are located. Names of IPC sockets are derived from this path.