### PR TITLE
Survive absence of LibreOffice configuration

### DIFF
--- a/etp-backend/src/main/clj/solita/common/libreoffice.clj
+++ b/etp-backend/src/main/clj/solita/common/libreoffice.clj
@@ -28,7 +28,10 @@
 
 (defn populate-tmpdir [path]
   (let [src-dir (config-path)
-        cmd ["cp" "-r" src-dir (str path "/config")]
+        dst-dir (str path "/config")
+        cmd (if (.exists (io/file  src-dir))
+              ["cp" "-r" src-dir dst-dir]
+              ["mkdir" dst-dir])
         result (apply shell/sh cmd)]
     (when (not (= 0 (:exit result)))
       (throw (IOException. (:err result))))))


### PR DESCRIPTION
Normally, if the LibreOffice configuration directory is present, it
will be used to initialize the temporary UserInstallation
(i.e. config) directory for a single LibreOffice run.

Previously the code would fail with an IOException if the
configuration directory is absent. With this change, the absence will
be silently ignored. This is mainly to make it more convenient to test
the backend.