### PR TITLE
Accept JWT with a slightly old timestamp

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/jwt.clj
+++ b/etp-backend/src/main/clj/solita/etp/jwt.clj
@@ -48,7 +48,8 @@
 
 (defn verified-jwt-payload [jwt public-key]
   (if (and jwt public-key)
-    (jwt/unsign jwt public-key {:alg (-> jwt jwe/decode-header :alg)})
+    (jwt/unsign jwt public-key {:alg (-> jwt jwe/decode-header :alg)
+                                :leeway 15})
     (log/warn "JWT verification was not possible due to missing token or public key")))
 
 (defn alb-headers [{:keys [headers]}]


### PR DESCRIPTION
This addresses AE-1073

The unsign function accepts a leeway parameter, which is an integer
number of seconds. The expiration have expired this short period of
time ago, to account for the time that passes between the main JWT
check and the additional check done in the application backend.