### PR TITLE
AE-1278 Add API for deleting sivu without parent

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/sivu.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/sivu.clj
@@ -47,4 +47,15 @@
                            #(api-response/put-response
                              (sivu-service/update-sivu! db id (:body parameters))
                              (str "Sivu " id " does not exist."))
-                           sivu-exceptions))}}]]]])
+                           sivu-exceptions))}
+       :delete {:summary "Poista sivu"
+                :access  rooli-service/paakayttaja?
+                :parameters {:path {:id common-schema/Key}}
+                :responses {200 {:body nil}
+                            404 {:body schema/Str}}
+                :handler (fn [{{{:keys [id]} :path} :parameters :keys [db]}]
+                           (api-response/with-exceptions
+                             #(api-response/put-response
+                               (sivu-service/delete-sivu! db id)
+                               (str "Sivu " id " does not exist."))
+                             sivu-exceptions))}}]]]])

--- a/etp-backend/src/main/clj/solita/etp/service/sivu.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/sivu.clj
@@ -15,6 +15,9 @@
 (defn add-sivu! [db sivu]
   (sivu-db/insert-sivu<! db sivu))
 
+(defn delete-sivu! [db id]
+  (sivu-db/delete-sivu! db {:id id}))
+
 (defn update-sivu! [db id sivu]
   (first (db/with-db-exception-translation
            jdbc/update! db :sivu sivu ["id = ?" id] db/default-opts)))

--- a/etp-backend/src/main/sql/solita/etp/db/sivu.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/sivu.sql
@@ -21,6 +21,9 @@ where
   id = :id and
   (:paakayttaja or published);
 
+-- name: delete-sivu!
+delete from sivu where id = :id;
+
 -- name: insert-sivu<!
 insert into sivu (title, body, parent_id, ordinal, published)
 values (:title, :body, :parent-id, :ordinal, :published)

--- a/etp-backend/src/test/clj/solita/etp/service/sivu_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/sivu_test.clj
@@ -77,6 +77,19 @@
                                 kayttaja-test-data/paakayttaja
                                 sivu-id)))))
 
+(t/deftest delete-leaf-sivu
+  (let [ds (test-data-set)
+        parent-ids (->> ds :sivut (map :parent-id) set)
+        sivu (->> ds :sivut (filter #(not (contains? parent-ids (:id %))))  first)
+        sivu-id (:id sivu)]
+    (t/is (not (nil? (service/find-sivu ts/*db*
+                                     kayttaja-test-data/paakayttaja
+                                     sivu-id))))
+    (service/delete-sivu! ts/*db* sivu-id)
+    (t/is (nil? (service/find-sivu ts/*db*
+                                   kayttaja-test-data/paakayttaja
+                                   sivu-id)))))
+
 (t/deftest update-title
   (let [ds (test-data-set)
         sivu (-> ds :sivut first)

--- a/etp-db/src/main/sql/migration/afterMigrate.sql
+++ b/etp-db/src/main/sql/migration/afterMigrate.sql
@@ -13,4 +13,4 @@ grant insert, update on table liite to etp_app;
 grant insert, update on table viestiketju to etp_app;
 grant insert, update on table viesti to etp_app;
 grant insert, update on table vastaanottaja to etp_app;
-grant insert, update on table sivu to etp_app;
+grant insert, update, delete on table sivu to etp_app;


### PR DESCRIPTION
As of now, an exception will be produced if the API user attempts to
delete a page that still has a parent.