### PR TITLE
Rename from put-response to ok|not-found

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/energiatodistus_crud.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/energiatodistus_crud.clj
@@ -61,7 +61,7 @@
              :responses  {200 {:body nil}
                           404 {:body schema/Str}}
              :handler    (fn [{{{:keys [id]} :path} :parameters :keys [db whoami]}]
-                           (api-response/put-response
+                           (api-response/ok|not-found
                              (energiatodistus-service/delete-energiatodistus-luonnos!
                                db whoami id)
                              (str "Energiatodistus luonnos " id " does not exists.")))}}])
@@ -76,7 +76,7 @@
            :responses  {200 {:body nil}
                         404 {:body schema/Str}}
            :handler    (fn [{{{:keys [id]} :path :keys [body]} :parameters :keys [db]}]
-                         (api-response/put-response
+                         (api-response/ok|not-found
                            (energiatodistus-service/set-energiatodistus-discarded! db id body)
                            (str (if body "Signed" "Discarded")
                                 " energiatodistus " id " does not exists.")))}}])

--- a/etp-backend/src/main/clj/solita/etp/api/energiatodistus_liite.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/energiatodistus_liite.clj
@@ -77,7 +77,7 @@
               :handler    (fn [{{{:keys [id liite-id]} :path}
                                :parameters
                                :keys [db whoami]}]
-                          (api-response/put-response
+                          (api-response/ok|not-found
                               (liite-service/delete-liite! db whoami liite-id)
                               (str "Energiatodistuksen " id " liite " liite-id " does not exists.")))}}]
 

--- a/etp-backend/src/main/clj/solita/etp/api/kayttaja.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/kayttaja.clj
@@ -39,7 +39,7 @@
                          404 {:body schema/Str}}
              :handler (fn [{{{:keys [id]} :path} :parameters
                             :keys [db whoami parameters]}]
-                        (api-response/put-response
+                        (api-response/ok|not-found
                          (kayttaja-service/update-kayttaja!
                           db whoami id (:body parameters))
                          (str "Käyttäjä " id " does not exists or käyttäjä is laatija.")))}}]

--- a/etp-backend/src/main/clj/solita/etp/api/laatija.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/laatija.clj
@@ -49,7 +49,7 @@
                          404 {:body schema/Str}}
              :handler (fn [{{{:keys [id]} :path} :parameters
                            :keys [db whoami parameters]}]
-                        (api-response/put-response
+                        (api-response/ok|not-found
                          (kayttaja-laatija-service/update-kayttaja-laatija!
                           db whoami id (:body parameters))
                          (str "Laatija " id " does not exists.")))}}]
@@ -79,7 +79,7 @@
                                      :yritys-id common-schema/Key}}
                  :responses  {200 {:body nil}}
                  :handler    (fn [{{{:keys [id yritys-id]} :path} :parameters :keys [db whoami]}]
-                               (api-response/put-response
+                               (api-response/ok|not-found
                                  (laatija-service/detach-laatija-yritys! db whoami id yritys-id)
                                  (str "Laatija and yritys liitos " id "/" yritys-id " does not exist.")))}}]]]]
    ["/patevyydet"

--- a/etp-backend/src/main/clj/solita/etp/api/response.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/response.clj
@@ -7,7 +7,7 @@
     (r/not-found not-found)
     (r/response body)))
 
-(defn put-response [updated not-found]
+(defn ok|not-found [updated not-found]
   (if (or (nil? updated) (= updated 0))
     (r/not-found not-found)
     (r/response nil)))

--- a/etp-backend/src/main/clj/solita/etp/api/sivu.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/sivu.clj
@@ -44,7 +44,7 @@
                           404 {:body schema/Str}}
              :handler  (fn [{{{:keys [id]} :path} :parameters :keys [db parameters]}]
                          (api-response/with-exceptions
-                           #(api-response/put-response
+                           #(api-response/ok|not-found
                              (sivu-service/update-sivu! db id (:body parameters))
                              (str "Sivu " id " does not exist."))
                            sivu-exceptions))}
@@ -55,7 +55,7 @@
                             404 {:body schema/Str}}
                 :handler (fn [{{{:keys [id]} :path} :parameters :keys [db]}]
                            (api-response/with-exceptions
-                             #(api-response/put-response
+                             #(api-response/ok|not-found
                                (sivu-service/delete-sivu! db id)
                                (str "Sivu " id " does not exist."))
                              sivu-exceptions))}}]]]])

--- a/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
@@ -34,7 +34,7 @@
                     :responses  {200 {:body nil}
                                  404 {:body schema/Str}}
                     :handler    (fn [{{{:keys [id]} :path} :parameters :keys [db parameters]}]
-                                  (api-response/put-response
+                                  (api-response/ok|not-found
                                     (valvonta-service/update-valvonta!
                                       db id (-> parameters :body :active))
                                     (str "Energiatodistus " id " does not exists.")))}}]]])

--- a/etp-backend/src/main/clj/solita/etp/api/valvonta_oikeellisuus.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta_oikeellisuus.clj
@@ -110,7 +110,7 @@
                            404 {:body schema/Str}}
               :handler    (fn [{{{:keys [id toimenpide-id]} :path :keys [body]}
                                 :parameters :keys [db whoami]}]
-                            (api-response/put-response
+                            (api-response/ok|not-found
                               (valvonta-service/update-toimenpide!
                                 db whoami id toimenpide-id body)
                               (str "Toimenpide " id "/" toimenpide-id " does not exists.")))}}]
@@ -122,6 +122,6 @@
                 :responses {200 {:body nil}
                             404 {:body schema/Str}}
                 :handler (fn [{{{:keys [id toimenpide-id]} :path} :parameters :keys [db whoami]}]
-                           (api-response/put-response
+                           (api-response/ok|not-found
                              (valvonta-service/publish-toimenpide! db whoami id toimenpide-id)
                              (str "Toimenpide " id "/" toimenpide-id " does not exists.")))}}]]]]]])

--- a/etp-backend/src/main/clj/solita/etp/api/viesti.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/viesti.clj
@@ -55,7 +55,7 @@
              :responses  {200 {:body nil}
                           404 {:body schema/Str}}
              :handler    (fn [{{{:keys [id]} :path} :parameters :keys [db parameters]}]
-                           (api-response/put-response
+                           (api-response/ok|not-found
                             (viesti-service/update-ketju! db id (:body parameters))
                             (str "Ketju " id " does not exists.")))}}]
      ["/viestit"
@@ -65,7 +65,7 @@
               :responses  {200 {:body nil}
                            404 {:body schema/Str}}
               :handler    (fn [{{{:keys [id]} :path} :parameters :keys [db whoami parameters]}]
-                            (api-response/put-response
+                            (api-response/ok|not-found
                               (viesti-service/add-viesti! db whoami id (:body parameters))
                               (str "Ketju " id " does not exists.")))}}]]]
    ["/vastaanottajaryhmat"

--- a/etp-backend/src/main/clj/solita/etp/api/yritys.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/yritys.clj
@@ -43,7 +43,7 @@
              :responses  {200 {:body nil}
                           404 {:body schema/Str}}
              :handler    (fn [{{{:keys [id]} :path} :parameters :keys [db whoami parameters]}]
-                           (api-response/put-response
+                           (api-response/ok|not-found
                              (yritys-service/update-yritys! db whoami id (:body parameters))
                              (str "Yritys " id " does not exists.")))}}]
      ["/laatijat"


### PR DESCRIPTION
Uses of the function are not limited to PUT method. The new name
is derived from what the function does.