### PR TITLE
AE-1406 Always handle :include-kasitelty

### DIFF
--- a/etp-backend/src/main/sql/solita/etp/db/viesti.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/viesti.sql
@@ -7,10 +7,9 @@ select
     where vastaanottaja.viestiketju_id = viestiketju.id) vastaanottajat
   from viestiketju
 where
-  ((not viestiketju.kasitelty or :include-kasitelty) and (
-        viestiketju.kasittelija_id = :kasittelija-id or
-        ((viestiketju.kasittelija_id is not null) = :has-kasittelija))) or
-  (:kasittelija-id::int is null and :has-kasittelija::boolean is null)
+  ((not viestiketju.kasitelty) or :include-kasitelty) and
+  (:kasittelija-id::int is null or viestiketju.kasittelija_id = :kasittelija-id) and
+  (:has-kasittelija::boolean is null or :has-kasittelija = (viestiketju.kasittelija_id is not null))
 order by (select max(sent_time) from viesti where viestiketju_id = viestiketju.id) desc
 limit :limit offset :offset;
 
@@ -33,10 +32,9 @@ limit :limit offset :offset;
 -- name: select-count-all-viestiketjut
 select count(*) count from viestiketju
 where
-  ((not viestiketju.kasitelty or :include-kasitelty) and (
-        viestiketju.kasittelija_id = :kasittelija-id or
-        ((viestiketju.kasittelija_id is not null) = :has-kasittelija))) or
-  (:kasittelija-id::int is null and :has-kasittelija::boolean is null);
+  ((not viestiketju.kasitelty) or :include-kasitelty) and
+  (:kasittelija-id::int is null or viestiketju.kasittelija_id = :kasittelija-id) and
+  (:has-kasittelija::boolean is null or :has-kasittelija = (viestiketju.kasittelija_id is not null));
 
 -- name: select-count-viestiketjut-for-kayttaja
 select count(*) count


### PR DESCRIPTION
The previous ketju search queries had a trailing OR branch that would
ignore the parameter, making it impossible to hide processed ketjus in
some combinations of parameters.

The queries are rephrased so that it is hopefully easy to see that the
three available constraints can be applied independently from each
other.