### PR TITLE
Mark find-kayttajat as private

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/viesti.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/viesti.clj
@@ -63,7 +63,7 @@
   (map #(flat/flat->tree #"\$" %)
        (viesti-db/select-viestit db {:id viestiketju-id :reader-id (:id whoami)})))
 
-(defn find-kayttajat [db]
+(defn- find-kayttajat [db]
   (->> db viesti-db/select-kayttajat (group-by :id) (map/map-values first)))
 
 (defn- assoc-join-viestit [db whoami ketju]


### PR DESCRIPTION
The find-kayttajat function is not references from elsewhere, so it
seems suitable for being defined with defn-.

The prevailing style in etp.service.viesti namespace seems to make
much use of defn-, so this makes the namespace more consistent.