### PR TITLE
move et tila related functions to a separate namespace

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_pdf.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_pdf.clj
@@ -7,6 +7,7 @@
             [solita.common.xlsx :as xlsx]
             [solita.common.certificates :as certificates]
             [solita.common.libreoffice :as libreoffice]
+            [solita.etp.service.energiatodistus-tila :as energiatodistus-tila]
             [solita.etp.service.energiatodistus :as energiatodistus-service]
             [solita.etp.service.complete-energiatodistus :as complete-energiatodistus-service]
             [solita.etp.service.file :as file-service]
@@ -100,7 +101,7 @@
       {:path [:perustiedot :yritys :nimi]}
       {:f (fn [_] (.format date-formatter (LocalDate/now)))}
       {:f (fn [{:keys [tila-id]}]
-            (when (and tila-id (= (energiatodistus-service/tila-key tila-id) :in-signing))
+            (when (and tila-id (= (energiatodistus-tila/tila-key tila-id) :in-signing))
               (.format date-formatter (.plusYears (LocalDate/now) 10))))}]
    1 [{:path [:id]}
       {:f #(-> % :lahtotiedot :lammitetty-nettoala (formats/format-number 1 false) (str " m²"))}
@@ -703,7 +704,7 @@
       (generate-pdf-as-input-stream complete-energiatodistus kieli true))))
 
 (defn do-when-signing [{:keys [tila-id]} f]
-  (case (energiatodistus-service/tila-key tila-id)
+  (case (energiatodistus-tila/tila-key tila-id)
     :in-signing (f)
     :draft :not-in-signing
     :deleted :not-in-signing

--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_tila.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_tila.clj
@@ -1,0 +1,15 @@
+(ns solita.etp.service.energiatodistus-tila)
+
+(def ^:private tilat [:draft :in-signing :signed :discarded :replaced :deleted])
+
+(defn tila-key [tila-id] (nth tilat tila-id))
+
+(defn- in-tila? [tila-id energiatodistus]
+  (= (:tila-id energiatodistus) tila-id))
+
+(def draft? (partial in-tila? 0))
+(def in-signing? (partial in-tila? 1))
+(def signed? (partial in-tila? 2))
+(def discarded? (partial in-tila? 3))
+(def replaced? (partial in-tila? 4))
+(def deleted? (partial in-tila? 5))

--- a/etp-backend/src/test/clj/solita/etp/service/energiatodistus_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/energiatodistus_test.clj
@@ -7,6 +7,7 @@
             [solita.etp.test-data.kayttaja :as kayttaja-test-data]
             [solita.etp.test-data.laatija :as laatija-test-data]
             [solita.etp.test-data.energiatodistus :as energiatodistus-test-data]
+            [solita.etp.service.energiatodistus-tila :as energiatodistus-tila]
             [solita.etp.service.energiatodistus :as service]))
 
 (t/use-fixtures :each ts/fixture)
@@ -39,7 +40,7 @@
                     (xmap/dissoc-in [:tulokset :e-luku]))))
 
 (defn energiatodistus-tila [id]
-  (-> (service/find-energiatodistus ts/*db* id) :tila-id service/tila-key))
+  (-> (service/find-energiatodistus ts/*db* id) :tila-id energiatodistus-tila/tila-key))
 
 (t/deftest add-and-find-energiatodistus-test
   (let [{:keys [laatijat energiatodistukset]} (test-data-set)]


### PR DESCRIPTION
simplify logic using tila predicate-functions (note tila-key can and should still be used in more complex cases e.g. in match/case functions)