### PR TITLE
AE-1564 Rearrange select-valvonnat-paakayttaja

### DIFF
--- a/etp-backend/src/main/sql/solita/etp/db/valvonta-oikeellisuus.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/valvonta-oikeellisuus.sql
@@ -76,8 +76,7 @@ limit :limit offset :offset;
 
 -- name: count-valvonnat-paakayttaja
 with last_toimenpide as (
-  select distinct on (toimenpide.energiatodistus_id) toimenpide.*,
-    vo_toimenpide_ongoing(toimenpide) ongoing
+  select distinct on (toimenpide.energiatodistus_id) toimenpide.*
   from vo_toimenpide toimenpide
   order by toimenpide.energiatodistus_id, coalesce(toimenpide.publish_time, toimenpide.create_time) desc
 )
@@ -86,7 +85,7 @@ from energiatodistus
   left join last_toimenpide on last_toimenpide.energiatodistus_id = energiatodistus.id
 where
   (energiatodistus.valvonta$pending or
-   last_toimenpide.ongoing or
+   vo_toimenpide_ongoing(last_toimenpide) or
    (:include-closed and last_toimenpide.id is not null)) and
   (energiatodistus.valvonta$valvoja_id = :valvoja-id or
    (energiatodistus.valvonta$valvoja_id is not null) = :has-valvoja or

--- a/etp-backend/src/main/sql/solita/etp/db/valvonta-oikeellisuus.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/valvonta-oikeellisuus.sql
@@ -77,8 +77,7 @@ limit :limit offset :offset;
 -- name: count-valvonnat-paakayttaja
 with last_toimenpide as (
   select distinct on (toimenpide.energiatodistus_id) toimenpide.*,
-    vo_toimenpide_ongoing(toimenpide) ongoing,
-      lag(toimenpide.deadline_date) over (order by toimenpide.id) previous_deadline_date
+    vo_toimenpide_ongoing(toimenpide) ongoing
   from vo_toimenpide toimenpide
   order by toimenpide.energiatodistus_id, coalesce(toimenpide.publish_time, toimenpide.create_time) desc
 )


### PR DESCRIPTION
The data for last_toimenpide is prepared up-front as a WITH query
[1]. This way, it does not get evaluated separately for every
Energiatodistus.

[1] https://www.postgresql.org/docs/current/queries-with.html