### PR TITLE
AE-1583 - fix previous_deadline_date

### DIFF
--- a/etp-backend/src/main/sql/solita/etp/db/valvonta-oikeellisuus.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/valvonta-oikeellisuus.sql
@@ -3,9 +3,12 @@
 with last_toimenpide as (
   select distinct on (toimenpide.energiatodistus_id) toimenpide.*,
     vo_toimenpide_ongoing(toimenpide) ongoing,
-      lag(toimenpide.deadline_date) over (order by toimenpide.id) previous_deadline_date
+    lead(toimenpide.deadline_date) over
+      (partition by toimenpide.energiatodistus_id
+       order by toimenpide.create_time desc, toimenpide.id desc)
+      previous_deadline_date
   from vo_toimenpide toimenpide
-  order by toimenpide.energiatodistus_id, coalesce(toimenpide.publish_time, toimenpide.create_time) desc
+  order by toimenpide.energiatodistus_id, toimenpide.create_time desc, toimenpide.id desc
 )
 select
   energiatodistus.*,


### PR DESCRIPTION
previous_deadline_date is picked from previous toimenpide of this energiatodistus not from previous toimenpide of all ets. Unify cte order with lead over for performance reasons.