### PR TITLE
Feature/ae 1129 revert

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/schema/public_energiatodistus.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/public_energiatodistus.clj
@@ -35,9 +35,7 @@
         {:perustiedot Perustiedot
          :lahtotiedot Lahtotiedot
          :tulokset    Tulokset}))
-      (dissoc :laatija-fullname
-              :laatija-id
-              :laskutusaika)))
+      (dissoc :laskutusaika)))
 
 (def Energiatodistus2013
   (-> (energiatodistus-versio 2013)

--- a/etp-backend/src/test/clj/solita/etp/schema/public_energiatodistus_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/schema/public_energiatodistus_test.clj
@@ -5,7 +5,9 @@
              :as public-energiatodistus-schema]))
 
 (def example-2013
-  {:allekirjoitusaika (java.time.Instant/now)
+  {:laatija-fullname "Liisa Laatija"
+   :laatija-id 0
+   :allekirjoitusaika (java.time.Instant/now)
    :voimassaolo-paattymisaika (java.time.Instant/now)
    :korvaava-energiatodistus-id nil
    :tulokset {:e-luku 10


### PR DESCRIPTION
Tämä rikkoikin kipapuolen hakutulokset aika pahasti

Public frontin vastaavia muutoksia ei tarvitse peruuttaa, koska uusimmassa frontissa kyllä selvitään vaikka tietoa ilmestyy takaisin näkyviin.