### PR TITLE
AE-1590 Passivoitu -tieto näkyviin private/valvonta/valvojat -rajapinnassa

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
@@ -12,8 +12,8 @@
     ["/valvojat"
      {:conflicting true
       :get         {:summary   "Hae kaikki valvojat."
-                    :responses {200 {:body [(merge common-schema/Kayttaja
-                                                   {:passivoitu schema/Bool})]}}
+                    :responses {200 {:body [(assoc common-schema/Kayttaja
+                                                   :passivoitu schema/Bool)]}}
                     :handler   (fn [{:keys [db]}]
                                  (r/response (valvonta-service/find-valvojat db)))}}]
     ["/:id"

--- a/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
@@ -12,7 +12,8 @@
     ["/valvojat"
      {:conflicting true
       :get         {:summary   "Hae kaikki valvojat."
-                    :responses {200 {:body [common-schema/Kayttaja]}}
+                    :responses {200 {:body [(merge common-schema/Kayttaja
+                                                   {:passivoitu schema/Bool})]}}
                     :handler   (fn [{:keys [db]}]
                                  (r/response (valvonta-service/find-valvojat db)))}}]
     ["/:id"

--- a/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta.clj
@@ -14,6 +14,7 @@
       :get         {:summary   "Hae kaikki valvojat."
                     :responses {200 {:body [(assoc common-schema/Kayttaja
                                                    :passivoitu schema/Bool)]}}
+                    :access    (some-fn rooli-service/paakayttaja? rooli-service/laatija?)
                     :handler   (fn [{:keys [db]}]
                                  (r/response (valvonta-service/find-valvojat db)))}}]
     ["/:id"

--- a/etp-backend/src/main/sql/solita/etp/db/valvonta.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/valvonta.sql
@@ -1,6 +1,6 @@
 
 -- name: select-valvojat
-select id, etunimi, sukunimi, rooli_id from kayttaja WHERE rooli_id = 2;
+select id, etunimi, sukunimi, rooli_id, passivoitu from kayttaja WHERE rooli_id = 2;
 
 -- name: select-valvonta
 select valvonta active from energiatodistus where id = :id


### PR DESCRIPTION
Tämä pitää mergetä ennen kuin [etp-front/802](https://github.com/solita/etp-front/pull/802), jotta jälkimmäisen tarvitsema `passivoitu` -attribuutti on saatavilla.