### PR TITLE
AE-1630 Add missing check for deleted valvonta

### DIFF
--- a/etp-backend/src/main/sql/solita/etp/db/valvonta-kaytto.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/valvonta-kaytto.sql
@@ -26,7 +26,8 @@ from vk_valvonta valvonta
     where valvonta.id = toimenpide.valvonta_id
     order by coalesce(toimenpide.publish_time, toimenpide.create_time) desc
     limit 1) last_toimenpide on true
-where not valvonta.deleted and
+where
+  not valvonta.deleted and
   (last_toimenpide.id is null or last_toimenpide.type_id <> 5 or :include-closed) and
   (valvonta.valvoja_id = :valvoja-id or
     (valvonta.valvoja_id is not null) = :has-valvoja or
@@ -49,6 +50,7 @@ left join lateral (
   order by coalesce(toimenpide.publish_time, toimenpide.create_time) desc
   limit 1) last_toimenpide on true
 where
+  not valvonta.deleted and
   (last_toimenpide.id is null or last_toimenpide.type_id <> 5 or :include-closed) and
   (valvonta.valvoja_id = :valvoja-id or
    (valvonta.valvoja_id is not null) = :has-valvoja or


### PR DESCRIPTION
Paging in käytön valvonta was falling over a bit, because the count of
results was not counting with exactly the same search conditions as
the query that would fetch the results.

The code layout was also changed so that the where keyword is alone on
its own line and all the query conditions are in a separate indented
section.