### PR TITLE
AE-1614 Add cache-control headers to CSV downloads

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/energiatodistus.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/energiatodistus.clj
@@ -91,7 +91,7 @@
 
 
 
-(defn csv-route [energiatodistukset-csv]
+(defn csv-route [energiatodistukset-csv cache-ttl-seconds]
   ["/csv/energiatodistukset.csv"
    {:get {:summary    "Hae energiatodistusten tiedot CSV-tiedostona"
           :parameters {:query energiatodistus-schema/EnergiatodistusSearch}
@@ -103,7 +103,8 @@
                                          db whoami (update query :where json/read-value))]
                              (api-stream/result->async-channel
                               request
-                              (api-response/csv-response-headers "energiatodistukset.csv" false)
+                              (merge (api-response/csv-response-headers "energiatodistukset.csv" false)
+                                     (api-response/async-cache-headers cache-ttl-seconds))
                               result))
                           search-exceptions))}}])
 
@@ -112,7 +113,7 @@
    [["/energiatodistukset"
      (search-route public-energiatodistus-schema/Energiatodistus)
      search-count-route
-     (csv-route energiatodistus-csv-service/energiatodistukset-public-csv)
+     (csv-route energiatodistus-csv-service/energiatodistukset-public-csv 43200)
      luokittelut-api/routes]]))
 
 (def private-routes
@@ -120,7 +121,7 @@
     [["/energiatodistukset"
       (search-route valvonta-schema/Energiatodistus+Valvonta)
       search-count-route
-      (csv-route energiatodistus-csv-service/energiatodistukset-private-csv)
+      (csv-route energiatodistus-csv-service/energiatodistukset-private-csv 900)
 
       ["/xlsx/energiatodistukset.xlsx"
        {:get {:summary    "Hae energiatodistusten tiedot XLSX-tiedostona"

--- a/etp-backend/src/main/clj/solita/etp/api/response.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/response.clj
@@ -63,6 +63,11 @@
 (defn csv-response-headers [filename inline?]
   (file-response-headers "text/csv" inline? filename))
 
+;; This is only intended for asynchronous responses. Otherwise, use
+;; the wrap-cache-control middleware.
+(defn async-cache-headers [ttl-seconds]
+  {"Cache-Control" (str "max-age=" ttl-seconds ",public")})
+
 (defn file-response [body filename content-type inline? not-found]
   (if (nil? body)
     (r/not-found not-found)


### PR DESCRIPTION
The mechanism for asynchronous streaming of response bodies seems to
be right now mutually exlusive with using the wrap-cache-control
middleware.

As a workaround, this change inserts the headers right where they get
inserted into the result->async-channel function.