### PR TITLE
AE-1620 Restrict yritys API to members only

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/yritys.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/yritys.clj
@@ -51,9 +51,9 @@
        {:get {:summary    "Hae yrityksen laatijat"
               :parameters {:path {:id common-schema/Key}}
               :responses  {200 {:body [yritys-schema/Laatija]}}
-              :handler    (fn [{{{:keys [id]} :path} :parameters :keys [db]}]
+              :handler    (fn [{{{:keys [id]} :path} :parameters :keys [db whoami]}]
                             (r/response
-                              (yritys-service/find-laatijat db id)))}}]
+                              (yritys-service/find-laatijat db whoami id)))}}]
       ["/:laatija-id"
        {:put {:summary    "Liitä laatija yritykseen - hyväksytty"
               :access     (some-fn rooli-service/paakayttaja? rooli-service/laatija?)

--- a/etp-backend/src/main/clj/solita/etp/service/laatija.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/laatija.clj
@@ -123,19 +123,19 @@
   (if (= laatija-id (:id whoami))
     (do
       (laatija-db/insert-laatija-yritys!
-       db
-       (map/bindings->map laatija-id yritys-id))
+        db (map/bindings->map laatija-id yritys-id))
       nil)
-    (exception/throw-forbidden!)))
+    (exception/throw-forbidden!
+      (str "User " (:id whoami) " is not allowed to add laatija: " laatija-id))))
 
 (defn detach-laatija-yritys! [db whoami laatija-id yritys-id]
   (if (or (rooli-service/paakayttaja? whoami)
           (= laatija-id (:id whoami))
-          (yritys-service/laatija-in-yritys? db whoami (:id whoami) yritys-id))
+          (yritys-service/laatija-in-yritys? db (:id whoami) yritys-id))
     (laatija-db/delete-laatija-yritys!
-     db
-     (map/bindings->map laatija-id yritys-id))
-    (exception/throw-forbidden!)))
+      db (map/bindings->map laatija-id yritys-id))
+    (exception/throw-forbidden!
+      (str "User " (:id whoami) " is not allowed to detach laatija: " laatija-id))))
 
 (defn count-public-laatijat [db]
   (first (laatija-db/select-count-public-laatijat db)))

--- a/etp-backend/src/main/clj/solita/etp/service/laatija.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/laatija.clj
@@ -131,7 +131,7 @@
 (defn detach-laatija-yritys! [db whoami laatija-id yritys-id]
   (if (or (rooli-service/paakayttaja? whoami)
           (= laatija-id (:id whoami))
-          (yritys-service/laatija-in-yritys? db (:id whoami) yritys-id))
+          (yritys-service/laatija-in-yritys? db whoami (:id whoami) yritys-id))
     (laatija-db/delete-laatija-yritys!
      db
      (map/bindings->map laatija-id yritys-id))

--- a/etp-backend/src/main/clj/solita/etp/service/yritys.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/yritys.clj
@@ -15,23 +15,23 @@
 (defn find-all-yritykset [db]
   (yritys-db/select-all-yritykset db))
 
-(defn- find-laatijat-nocheck [db id]
-  (yritys-db/select-laatijat db {:id id}))
-
-(defn- laatija-in-laatijat? [laatija-id laatijat]
+(defn- laatija-in-yritys-laatijat? [laatija-id yritys-laatijat]
   (some #(= laatija-id (:id %))
-        (filter laatija-yritys/accepted? laatijat)))
+        (filter laatija-yritys/accepted? yritys-laatijat)))
 
-(defn- assert-permission-laatijat! [whoami yritys-id laatijat]
+(defn- assert-permission! [whoami yritys-id yritys-laatijat]
   (if (or (rooli-service/paakayttaja? whoami)
-          (laatija-in-laatijat? (:id whoami) laatijat))
-    laatijat
+          (laatija-in-yritys-laatijat? (:id whoami) yritys-laatijat))
+    yritys-laatijat
     (exception/throw-forbidden!
-     (str "User " (:id whoami) " is not paakayttaja or "
-          "does not belong to organization: " yritys-id))))
+      (str "User " (:id whoami) " is not paakayttaja or "
+           "does not belong to organization: " yritys-id))))
 
-(defn find-laatijat [db whoami id]
-  (assert-permission-laatijat! whoami id (find-laatijat-nocheck db id)))
+(defn find-laatijat
+  ([db id] (yritys-db/select-laatijat db {:id id}))
+  ([db whoami id] (assert-permission! whoami id (find-laatijat db id))))
+
+(defn db-assert-permission! [db whoami id] (find-laatijat db whoami id))
 
 (defn find-all-laskutuskielet [db]
   (yritys-db/select-all-laskutuskielet db))
@@ -39,29 +39,17 @@
 (defn find-all-verkkolaskuoperaattorit [db]
   (yritys-db/select-all-verkkolaskuoperaattorit db))
 
-(defn laatija-in-yritys? [db whoami laatija-id yritys-id]
-  (let [find-impl (if (= laatija-id (:id whoami))
-                    ;; Laatija may check their own status
-                    (fn [] (find-laatijat-nocheck db yritys-id))
-                    ;; Trying to check other people requires going
-                    ;; through the usual visibility checks
-                    (fn [] (find-laatijat db whoami yritys-id))) ]
-    (some #(= laatija-id (:id %))
-          (filter laatija-yritys/accepted? (find-impl)))))
-
-
-(defn assert-permission! [db whoami yritys-id]
-  (let [laatijat (find-laatijat-nocheck db yritys-id)]
-    (assert-permission-laatijat! whoami yritys-id laatijat)))
+(defn laatija-in-yritys? [db laatija-id yritys-id]
+  (laatija-in-yritys-laatijat? laatija-id (find-laatijat db yritys-id)))
 
 (defn update-yritys!
   [db whoami id yritys]
-  (assert-permission! db whoami id)
+  (db-assert-permission! db whoami id)
   (yritys-db/update-yritys! db (assoc yritys :id id)))
 
 (defn add-laatija-yritys!
   ([db whoami laatija-id yritys-id]
-   (assert-permission! db whoami yritys-id)
+   (db-assert-permission! db whoami yritys-id)
    (add-laatija-yritys! db laatija-id yritys-id))
   ([db laatija-id yritys-id]
    (yritys-db/insert-laatija-yritys!
@@ -70,7 +58,8 @@
 
 (defn add-yritys!
   ([db whoami yritys]
-    (jdbc/with-db-transaction [db db]
-      (let [id (:id (yritys-db/insert-yritys<! db yritys))]
-        (add-laatija-yritys! db (:id whoami) id)
-        id))))
+   (jdbc/with-db-transaction
+     [db db]
+     (let [id (:id (yritys-db/insert-yritys<! db yritys))]
+       (add-laatija-yritys! db (:id whoami) id)
+       id))))


### PR DESCRIPTION
Most of the yritys API is made available laatija users only where they
are members of the yritys. Without yritys membership, laatija may
still:

- Check if they themselves are members of the yritys
- Add a new yritys