### PR TITLE
AE-1655 - asha rajapinnan lokituksen parannus

### DIFF
--- a/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
@@ -77,7 +77,7 @@
                                                400
                                                "clj-http: status 400")]
     (t/is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Sending asiahallinta request failed."
+                            #"Asiahallinta request failed. Posting the request failed."
                             (asha-service/open-case!
                               {:request-id     "ETP-1"
                                :classification "05.03.02"

--- a/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
@@ -17,9 +17,9 @@
        :status response-status})))
 
 (t/deftest open-case-test
-  (binding [asha-service/make-send-request! (handle-request "asha/case-create-request.xml"
-                                                            "asha/case-create-response.xml"
-                                                             200)]
+  (binding [asha-service/post! (handle-request "asha/case-create-request.xml"
+                                               "asha/case-create-response.xml"
+                                               200)]
     (t/is (= (asha-service/open-case!
                {:sender-id      "test@example.com"
                 :request-id     "ETP-1"
@@ -30,9 +30,9 @@
              "ARA-05.03.02-2021-31"))))
 
 (t/deftest case-info-test
-  (binding [asha-service/make-send-request! (handle-request "asha/case-info-request.xml"
-                                                            "asha/case-info-response.xml"
-                                                            200)]
+  (binding [asha-service/post! (handle-request "asha/case-info-request.xml"
+                                               "asha/case-info-response.xml"
+                                               200)]
     (t/is (= (asha-service/case-info "test@example.com" "ETP-1" "ARA-05.03.02-2021-31")
              {:case-number    "ARA-05.03.02-2021-31"
               :id             38444
@@ -43,9 +43,9 @@
               :created        "2021-03-22T10:28:13+02:00"}))))
 
 (t/deftest action-info-test
-  (binding [asha-service/make-send-request! (handle-request "asha/action-info-request.xml"
-                                                            "asha/action-info-response.xml"
-                                                            200)]
+  (binding [asha-service/post! (handle-request "asha/action-info-request.xml"
+                                               "asha/action-info-response.xml"
+                                               200)]
     (t/is (= (asha-service/action-info "test@example.com" "ETP-1" "ARA-05.03.02-2021-8" "Vireillepano")
              {:processing-action
                         {:object-class         "ProcessingAction",
@@ -72,12 +72,12 @@
                                     :created              "2021-03-25T14:01:07+02:00"}}}))))
 
 (t/deftest case-create-without-sender-id-test
-  (binding [asha-service/make-send-request! (handle-request "asha/case-create-request-without-sender-id.xml"
-                                                            "asha/case-create-response-without-sender-id.xml"
-                                                            400
-                                                            "clj-http: status 400")]
+  (binding [asha-service/post! (handle-request "asha/case-create-request-without-sender-id.xml"
+                                               "asha/case-create-response-without-sender-id.xml"
+                                               400
+                                               "clj-http: status 400")]
     (t/is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Sending xml failed: clj-http: status 400"
+                            #"Sending asiahallinta request failed."
                             (asha-service/open-case!
                               {:request-id     "ETP-1"
                                :classification "05.03.02"
@@ -86,9 +86,9 @@
                                :description    "Helsinki, Katu 1"})))))
 
 (t/deftest execute-operation-attach-contact-test
-  (binding [asha-service/make-send-request! (handle-request "asha/execute-operation-attach-contact-request.xml"
-                                                            "asha/execute-operation-response.xml"
-                                                            200)]
+  (binding [asha-service/post! (handle-request "asha/execute-operation-attach-contact-request.xml"
+                                               "asha/execute-operation-response.xml"
+                                               200)]
     (t/is (nil? (asha-service/execute-operation! {:sender-id  "test@example.com"
                                                   :request-id "ETP-1"
                                                   :identity   {:case              {:number "ARA-05.03.02-2021-8"}
@@ -98,9 +98,9 @@
                                                                          :last-name  "Meikäläinen"}}})))))
 
 (t/deftest execute-operation-processing-action-test
-  (binding [asha-service/make-send-request! (handle-request "asha/execute-operation-create-processing-action-request.xml"
-                                                            "asha/execute-operation-response.xml"
-                                                            200)]
+  (binding [asha-service/post! (handle-request "asha/execute-operation-create-processing-action-request.xml"
+                                               "asha/execute-operation-response.xml"
+                                               200)]
     (t/is (nil? (asha-service/execute-operation! {:sender-id         "test@example.com"
                                                   :request-id        "ETP-1"
                                                   :identity          {:case              {:number "ARA-05.03.02-2021-8"}
@@ -113,9 +113,9 @@
                                                                                              :last-name  "Meikäläinen"}}})))))
 
 (t/deftest execute-operation-attach-document-test
-  (binding [asha-service/make-send-request! (handle-request "asha/execute-operation-attach-document-request.xml"
-                                                            "asha/execute-operation-response.xml"
-                                                            200)]
+  (binding [asha-service/post! (handle-request "asha/execute-operation-attach-document-request.xml"
+                                               "asha/execute-operation-response.xml"
+                                               200)]
     (t/is (nil? (asha-service/execute-operation! {:sender-id  "test@example.com"
                                                   :request-id "ETP-1"
                                                   :identity   {:case              {:number "ARA-05.03.02-2021-8"}
@@ -125,9 +125,9 @@
                                                                            :content (String. (b64/encode (.getBytes "Test")) "UTF-8")}]}})))))
 
 (t/deftest execute-operation-proceed-operation-test
-  (binding [asha-service/make-send-request! (handle-request "asha/execute-operation-proceed-operation-request.xml"
-                                                            "asha/execute-operation-response.xml"
-                                                            200)]
+  (binding [asha-service/post! (handle-request "asha/execute-operation-proceed-operation-request.xml"
+                                               "asha/execute-operation-response.xml"
+                                               200)]
     (t/is (nil? (asha-service/proceed-operation!
                   "test@example.com"
                   "ETP-1"


### PR DESCRIPTION
Lokiin menee aina tiedot: endpoint-url, request  (excluding gdpr), response (original), cause