### PR TITLE
AE-1616 - fix test.

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/laatija.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/laatija.clj
@@ -154,7 +154,8 @@
 (def ^:private template (-> "viesti/patevyys-expiration.txt" io/resource slurp))
 
 (defn send-patevyys-expiration-messages!
-  [db {:keys [months-before-expiration fallback-window dryrun]
+  [db {:keys [months-before-expiration dryrun]
+       :or {dryrun false}
        :as   options}]
   (jdbc/with-db-transaction
     [db db]

--- a/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
@@ -198,7 +198,7 @@
         [id _] (laatija-test-data/generate-and-insert!)
         ^LocalDate now (LocalDate/now)
         system-id (rooli-service/system :communication)
-        options {:months-before-expiration 6 :fallback-window 0}]
+        options {:months-before-expiration 6 :fallback-window 5}]
     (service/update-laatija-by-id!
       ts/*db* id
       {:toteamispaivamaara (-> now (.minusYears 7) (.plusMonths 6))})


### PR DESCRIPTION
Jos pätevyys päättyy 2022-02-28, niin päättymismuistutus lähtee 2021-08-28. Päivinä 08-29, 08-30 ja 08-31 ei ole muistutusta koska helmikuusta ei vastaavia päiviä löydy. Fallback window 5 mahdollistaa testin toiminnan myös näinä päivänä.