### PR TITLE
Use parse-where for search-count-route

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/energiatodistus.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/energiatodistus.clj
@@ -86,7 +86,7 @@
                         (api-response/response-with-exceptions
                           #(energiatodistus-search-service/search-count
                              db whoami
-                             (update query :where json/read-value))
+                             (update query :where parse-where))
                           search-exceptions))}}])
 
 


### PR DESCRIPTION
It seems that this was forgotten when parse-where was added to
search-route.