### PR TITLE
AE-1593 Handle errors in XML parsing

### DIFF
--- a/etp-backend/src/main/clj/solita/common/xml.clj
+++ b/etp-backend/src/main/clj/solita/common/xml.clj
@@ -11,7 +11,7 @@
            (javax.xml XMLConstants)
            (javax.xml.stream XMLStreamException)
            (javax.xml.transform.stream StreamSource)
-           (javax.xml.validation SchemaFactory)
+           (javax.xml.validation SchemaFactory Schema)
            (org.xml.sax SAXException)))
 
 (def envelope-url "http://schemas.xmlsoap.org/soap/envelope/")
@@ -24,11 +24,14 @@
 (def emit xml/emit)
 (def emit-str xml/emit-str)
 
+(defn- xml-not-well-formed [e]
+  (ex-info (.getMessage e) {:type :xml-not-well-formed} e))
+
 (defn input-stream->xml [is]
   (try
     (xml/parse is)
     (catch Exception e
-      (throw (ex-info (.getMessage e) {:type :xml-not-well-formed} e)))))
+      (throw (xml-not-well-formed e)))))
 
 (defn string->xml [string]
   (xml/parse-str string))
@@ -70,17 +73,15 @@
 (defn xml->stream-source [xml]
   (-> xml xml/emit-str StringReader. StreamSource.))
 
-(defn schema-validation [xml schema]
+(defn validate-xsd! [xml ^Schema schema]
   (try
-    (when (-> schema .newValidator (.validate (xml->stream-source xml)) nil?)
-      {:valid? true})
+    (-> schema .newValidator (.validate (xml->stream-source xml)))
     (catch XMLStreamException e
       ;; Could happen if the lazy document loader did not perform full
       ;; parsing in the parse function.
-      (throw (ex-info (.getMessage e) {:type :xml-not-well-formed} e)))
+      (throw (xml-not-well-formed e)))
     (catch SAXException e
-      {:valid? false
-       :error (.getMessage e)})))
+      (throw (ex-info (.getMessage e) {:type :xml-xsd-validation-failed} e)))))
 
 (defn get-in-xml
   "Similar to get-in in core but works with xml. Keywords filter elements by

--- a/etp-backend/src/main/clj/solita/common/xml.clj
+++ b/etp-backend/src/main/clj/solita/common/xml.clj
@@ -24,7 +24,10 @@
 (def emit-str xml/emit-str)
 
 (defn input-stream->xml [is]
-  (xml/parse is))
+  (try
+    (xml/parse is)
+    (catch Exception e
+      (throw (ex-info (.getMessage e) {:type :invalid-xml} e)))))
 
 (defn string->xml [string]
   (xml/parse-str string))

--- a/etp-backend/src/main/clj/solita/etp/api/energiatodistus_xml.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/energiatodistus_xml.clj
@@ -334,7 +334,7 @@
       (-> (success-body id warnings)
           r/response))))
 
-(defn- xml-error-response [error]
+(defn- error->xml-response [error]
   (let [{:keys [type]} (ex-data error)
         msg (.getMessage error)
         response-fn (get error-response type)
@@ -358,4 +358,4 @@
                          (try
                            (handle-post db whoami body versio)
                            (catch clojure.lang.ExceptionInfo e
-                             (xml-error-response e)))))}})
+                             (error->xml-response e)))))}})

--- a/etp-backend/src/test/clj/solita/common/xml_test.clj
+++ b/etp-backend/src/test/clj/solita/common/xml_test.clj
@@ -1,7 +1,8 @@
 (ns solita.common.xml-test
   (:require [clojure.test :as t]
             [clojure.java.io :as io]
-            [solita.common.xml :as xml]))
+            [solita.common.xml :as xml]
+            [solita.etp.test :as etp-test]))
 
 (def xml-path "legacy-api/esimerkki-2018.xml")
 (def raw-xml (-> xml-path io/resource io/input-stream xml/input-stream->xml))
@@ -45,10 +46,9 @@
                    (xml/xml->stream-source raw-xml))))
 
 (t/deftest schema-validation-test
-  (t/is (= {:valid? true}
-           (xml/schema-validation xml-without-soap-envelope test-schema)))
-  (t/is (contains? (xml/schema-validation sanitized-xml test-schema)
-                   :error)))
+  (xml/validate-xsd! xml-without-soap-envelope test-schema)
+  (t/is (= (etp-test/catch-ex-data #(xml/validate-xsd! sanitized-xml test-schema))
+           {:type :xml-xsd-validation-failed})))
 
 (t/deftest get-in-xml-test
   (t/is (= "Kilpikonna"

--- a/etp-backend/src/test/clj/solita/etp/api/energiatodistus_xml_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/api/energiatodistus_xml_test.clj
@@ -5,7 +5,17 @@
             [schema-tools.coerce :as sc]
             [solita.common.xml :as xml]
             [solita.common.xml-test :as xml-test]
-            [solita.etp.api.energiatodistus-xml :as xml-api]))
+            [solita.etp.test-system :as ts]
+            [solita.etp.test-data.laatija :as laatija-test-data]
+            [solita.etp.api.energiatodistus-xml :as xml-api])
+  (:import (java.io FileInputStream)))
+
+(t/use-fixtures :each ts/fixture)
+
+(defn test-data-set []
+  (let [laatijat (laatija-test-data/generate-and-insert! 1)
+        laatija-id (-> laatijat keys sort first)]
+    {:laatija-id laatija-id}))
 
 (t/deftest xml->energiatodistus-test
   (let [energiatodistus (xml-api/xml->energiatodistus xml-test/xml-without-soap-envelope)]
@@ -15,3 +25,15 @@
     (t/is (= 0.5 (get-in energiatodistus [:tulokset :tekniset-jarjestelmat :jaahdytys :kaukojaahdytys])))
     (t/is (empty? (get-in energiatodistus [:toteutunut-ostoenergiankulutus :muu])))
     (t/is (= "p:Nimi" (get-in energiatodistus [:huomiot :lammitys :toimenpide 0 :nimi-fi])))))
+
+(t/deftest xml-post-test
+  (let [{:keys [laatija-id]} (test-data-set)
+        response
+        (with-open [body (FileInputStream. "src/test/resources/legacy-api/esimerkki-2018.xml")]
+          (let [handler (xml-api/handle-post 2018)
+                request {:db ts/*db*
+                         :whoami {:id laatija-id :rooli 0}
+                         :body body}]
+            (handler request)))]
+    (t/is (= 200 (:status response)))
+    (t/is (= 1 (-> (re-matches #".*<b:TodistusTunnus>(\d+)</b:TodistusTunnus>.*" (:body response)) second Integer/parseInt)))))

--- a/etp-backend/src/test/clj/solita/etp/api/energiatodistus_xml_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/api/energiatodistus_xml_test.clj
@@ -37,3 +37,13 @@
             (handler request)))]
     (t/is (= 200 (:status response)))
     (t/is (= 1 (-> (re-matches #".*<b:TodistusTunnus>(\d+)</b:TodistusTunnus>.*" (:body response)) second Integer/parseInt)))))
+
+(t/deftest xml-post-sansbody-test
+  (let [{:keys [laatija-id]} (test-data-set)
+        response
+        (let [handler (xml-api/handle-post 2018)
+              request {:db ts/*db*
+                       :whoami {:id laatija-id :rooli 0}
+                       :body nil}]
+          (handler request))]
+    (t/is (= 400 (:status response)))))

--- a/etp-backend/src/test/clj/solita/etp/api/energiatodistus_xml_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/api/energiatodistus_xml_test.clj
@@ -29,7 +29,7 @@
 (t/deftest xml-post-test
   (let [{:keys [laatija-id]} (test-data-set)
         response
-        (with-open [body (FileInputStream. "src/test/resources/legacy-api/esimerkki-2018.xml")]
+        (with-open [body (-> "legacy-api/esimerkki-2018.xml" io/resource io/input-stream)]
           (let [handler (xml-api/handle-post 2018)
                 request {:db ts/*db*
                          :whoami {:id laatija-id :rooli 0}


### PR DESCRIPTION
The existing error handler is moved outwards in the program. The
earlier assumption about ET validation failing does not hold, so this
warning is turned into a more generic one.