### PR TITLE
AE-1678 Luokittelu for yritystype

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/yritys.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/yritys.clj
@@ -94,4 +94,9 @@
     {:get {:summary    "Hae verkkolaskuoperaattorit -luokittelu"
            :responses  {200 {:body [yritys-schema/Verkkolaskuoperaattori]}}
            :handler    (fn [{:keys [db]}]
-                         (r/response (yritys-service/find-all-verkkolaskuoperaattorit db)))}}]])
+                         (r/response (yritys-service/find-all-verkkolaskuoperaattorit db)))}}]
+   ["/yritystyypit"
+    {:get {:summary "Hae yritystyypit -luokittelu"
+           :responses {200 {:body [common-schema/Luokittelu]}}
+           :handler (fn [{:keys [db]}]
+                      (r/response (yritys-service/find-all-yritystyypit db)))}}]])

--- a/etp-backend/src/main/clj/solita/etp/schema/yritys.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/yritys.clj
@@ -11,7 +11,8 @@
     :nimi                   schema/Str
     :verkkolaskuoperaattori (schema/maybe common-schema/Key)
     :verkkolaskuosoite      (schema/maybe common-schema/Verkkolaskuosoite)
-    :laskutuskieli          (schema/enum 0 1 2)))
+    :laskutuskieli          (schema/enum 0 1 2)
+    :type-id                common-schema/Key))
 
 (def Yritys
   "Yritys schema contains basic information about persistent yritys"

--- a/etp-backend/src/main/clj/solita/etp/service/luokittelu.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/luokittelu.clj
@@ -9,6 +9,7 @@
 
 (def find-roolit #(select-luokittelu % "rooli"))
 (def find-patevyystasot #(select-luokittelu % "patevyystaso"))
+(def find-yritystypes #(select-luokittelu % "yritystype"))
 
 (def find-kielisyys #(select-luokittelu % "kielisyys"))
 (def find-laatimisvaiheet #(select-luokittelu % "laatimisvaihe"))

--- a/etp-backend/src/main/clj/solita/etp/service/yritys.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/yritys.clj
@@ -47,6 +47,9 @@
 (defn find-all-verkkolaskuoperaattorit [db]
   (yritys-db/select-all-verkkolaskuoperaattorit db))
 
+(defn find-all-yritystyypit [db]
+  (yritys-db/select-all-yritystyypit db))
+
 (defn laatija-in-yritys? [db laatija-id yritys-id]
   (laatija-in-yritys-laatijat? laatija-id (find-laatijat db yritys-id)))
 

--- a/etp-backend/src/main/clj/solita/etp/service/yritys.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/yritys.clj
@@ -2,6 +2,7 @@
   (:require [solita.etp.db :as db]
             [solita.etp.exception :as exception]
             [solita.etp.service.laatija-yritys :as laatija-yritys]
+            [solita.etp.service.luokittelu :as luokittelu]
             [solita.etp.service.rooli :as rooli-service]
             [solita.common.map :as map]
             [clojure.java.jdbc :as jdbc]))
@@ -47,8 +48,7 @@
 (defn find-all-verkkolaskuoperaattorit [db]
   (yritys-db/select-all-verkkolaskuoperaattorit db))
 
-(defn find-all-yritystyypit [db]
-  (yritys-db/select-all-yritystyypit db))
+(def find-all-yritystyypit luokittelu/find-yritystypes)
 
 (defn laatija-in-yritys? [db laatija-id yritys-id]
   (laatija-in-yritys-laatijat? laatija-id (find-laatijat db yritys-id)))

--- a/etp-backend/src/main/sql/solita/etp/db/laskutus.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/laskutus.sql
@@ -3,6 +3,7 @@ SELECT e.id energiatodistus_id, e.allekirjoitusaika, e.laskuriviviite,
        k.id laatija_id, k.etunimi || ' ' || k.sukunimi laatija_nimi,
        k.henkilotunnus,
        y.id yritys_id, y.ytunnus, v.valittajatunnus, y.verkkolaskuosoite,
+       y.type_id,
 
        -- Fields depending on who should be invoiced.
        CASE WHEN e.laskutettava_yritys_id IS NULL THEN k.etunimi ||

--- a/etp-backend/src/main/sql/solita/etp/db/yritys.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/yritys.sql
@@ -1,22 +1,24 @@
 -- name: insert-yritys<!
-INSERT INTO yritys (ytunnus, nimi, verkkolaskuoperaattori, verkkolaskuosoite, laskutuskieli, jakeluosoite, vastaanottajan_tarkenne, postinumero, postitoimipaikka, maa)
-VALUES (:ytunnus, :nimi, :verkkolaskuoperaattori, :verkkolaskuosoite, :laskutuskieli, :jakeluosoite, :vastaanottajan-tarkenne, :postinumero, :postitoimipaikka, :maa)
+INSERT INTO yritys (ytunnus, nimi, verkkolaskuoperaattori, verkkolaskuosoite, laskutuskieli, jakeluosoite, vastaanottajan_tarkenne, postinumero, postitoimipaikka, maa, type_id)
+VALUES (:ytunnus, :nimi, :verkkolaskuoperaattori, :verkkolaskuosoite, :laskutuskieli, :jakeluosoite, :vastaanottajan-tarkenne, :postinumero, :postitoimipaikka, :maa, :type-id)
 RETURNING id
 
 -- name: update-yritys!
 update yritys set nimi = :nimi, ytunnus = :ytunnus, verkkolaskuoperaattori = :verkkolaskuoperaattori, verkkolaskuosoite = :verkkolaskuosoite, laskutuskieli = :laskutuskieli,
-       jakeluosoite = :jakeluosoite, vastaanottajan_tarkenne = :vastaanottajan-tarkenne, postinumero = :postinumero, postitoimipaikka = :postitoimipaikka, maa = :maa
+       jakeluosoite = :jakeluosoite, vastaanottajan_tarkenne = :vastaanottajan-tarkenne,
+       postinumero = :postinumero, postitoimipaikka = :postitoimipaikka, maa = :maa,
+       type_id = :type-id
 where id = :id
 
 -- name: select-yritys
 select id, ytunnus, nimi, verkkolaskuoperaattori, verkkolaskuosoite, laskutuskieli, deleted,
-       jakeluosoite, vastaanottajan_tarkenne as "vastaanottajan-tarkenne", postinumero, postitoimipaikka, maa
+       jakeluosoite, vastaanottajan_tarkenne as "vastaanottajan-tarkenne", postinumero, postitoimipaikka, maa, type_id
 from yritys
 where id = :id
 
 -- name: select-all-yritykset
 select id, ytunnus, nimi, verkkolaskuoperaattori, verkkolaskuosoite, laskutuskieli, deleted,
-       jakeluosoite, vastaanottajan_tarkenne as "vastaanottajan-tarkenne", postinumero, postitoimipaikka, maa
+       jakeluosoite, vastaanottajan_tarkenne as "vastaanottajan-tarkenne", postinumero, postitoimipaikka, maa, type_id
 from yritys
 
 --name: select-all-laskutuskielet
@@ -24,6 +26,9 @@ SELECT id, label_fi as "label-fi", label_sv as "label-sv", valid FROM laskutuski
 
 -- name: select-all-verkkolaskuoperaattorit
 SELECT id, valittajatunnus, nimi FROM verkkolaskuoperaattori order by nimi collate "fi-FI-x-icu", valittajatunnus;
+
+--name: select-all-yritystyypit
+SELECT id, label_fi as "label-fi", label_sv as "label-sv", valid FROM yritystype;
 
 -- name: select-laatijat
 with audit as (

--- a/etp-backend/src/main/sql/solita/etp/db/yritys.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/yritys.sql
@@ -27,9 +27,6 @@ SELECT id, label_fi as "label-fi", label_sv as "label-sv", valid FROM laskutuski
 -- name: select-all-verkkolaskuoperaattorit
 SELECT id, valittajatunnus, nimi FROM verkkolaskuoperaattori order by nimi collate "fi-FI-x-icu", valittajatunnus;
 
---name: select-all-yritystyypit
-SELECT id, label_fi as "label-fi", label_sv as "label-sv", valid FROM yritystype;
-
 -- name: select-laatijat
 with audit as (
   select row_number() over (

--- a/etp-backend/src/test/clj/solita/etp/test_data/yritys.clj
+++ b/etp-backend/src/test/clj/solita/etp/test_data/yritys.clj
@@ -6,7 +6,8 @@
 
 (defn generate-adds [n]
   (take n (map #(generators/complete {:ytunnus %
-                                      :verkkolaskuoperaattori (rand-int 32)}
+                                      :verkkolaskuoperaattori (rand-int 32)
+                                      :type-id 1}
                                      yritys-schema/YritysSave)
                generators/unique-ytunnukset)))
 

--- a/etp-db/src/main/sql/migration/repeatable/r-yritystype.sql
+++ b/etp-db/src/main/sql/migration/repeatable/r-yritystype.sql
@@ -1,0 +1,8 @@
+insert into yritystype (id, label_fi, label_sv, ordinal)
+values
+(1, 'Elinkeinoelämä (03)', 'Elinkeinoelämä (03) (sv)', 2),
+(2, 'Paikallishallinto (01)', 'Paikallishallinto (01) (sv)', 3)
+on conflict (id) do update set
+  label_fi = excluded.label_fi,
+  label_sv = excluded.label_sv,
+  ordinal = excluded.ordinal;

--- a/etp-db/src/main/sql/migration/repeatable/r-yritystype.sql
+++ b/etp-db/src/main/sql/migration/repeatable/r-yritystype.sql
@@ -1,7 +1,7 @@
 insert into yritystype (id, label_fi, label_sv, ordinal)
 values
-(1, 'Elinkeinoelämä (03)', 'Elinkeinoelämä (03) (sv)', 2),
-(2, 'Paikallishallinto (01)', 'Paikallishallinto (01) (sv)', 3)
+(1, 'Elinkeinoelämä (03)', 'Affärsliv (03)', 2),
+(2, 'Paikallishallinto (01)', 'Lokal förvaltning (01)', 3)
 on conflict (id) do update set
   label_fi = excluded.label_fi,
   label_sv = excluded.label_sv,

--- a/etp-db/src/main/sql/migration/v5-release-1.1/v5.30-yritys-type.sql
+++ b/etp-db/src/main/sql/migration/v5-release-1.1/v5.30-yritys-type.sql
@@ -1,10 +1,9 @@
 call create_classification('yritystype'::name);
+call audit.activate('yritystype'::name);
 
 -- The record used as default value is immediately inserted.
 -- See the repeatable schema for up-to-date contents.
 insert into yritystype (id, label_fi, label_sv, ordinal)
 values (1, 'Elinkeinoelämä (03)', 'Elinkeinoelämä (03) (sv)', 4);
-
-call audit.activate('yritystype'::name);
 
 alter table yritys add column type_id int not null default 1 references yritystype(id);

--- a/etp-db/src/main/sql/migration/v5-release-1.1/v5.30-yritys-type.sql
+++ b/etp-db/src/main/sql/migration/v5-release-1.1/v5.30-yritys-type.sql
@@ -1,0 +1,10 @@
+call create_classification('yritystype'::name);
+
+-- The record used as default value is immediately inserted.
+-- See the repeatable schema for up-to-date contents.
+insert into yritystype (id, label_fi, label_sv, ordinal)
+values (1, 'Elinkeinoelämä (03)', 'Elinkeinoelämä (03) (sv)', 4);
+
+call audit.activate('yritystype'::name);
+
+alter table yritys add column type_id int not null default 1 references yritystype(id);


### PR DESCRIPTION
This change adds:
- yritystype luokittelu with two values for now - elinkeinoelämä and
  paikallishallinto
- Endpoint /api/private/yritystyypit
- type-id column in yritys, referring to an yritystype
- In laskutus, set AsiakasluokitusKoodi and AsiakasTiliointiryhmakoodi
  based on yritystype