### PR TITLE
AE-1738 Close cases locally even if Asha gives an error

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
@@ -7,6 +7,7 @@
             [solita.etp.service.file :as file-service]
             [solita.etp.db :as db]
             [clojure.java.jdbc :as jdbc]
+            [clojure.tools.logging :as log]
             [solita.etp.service.luokittelu :as luokittelu]
             [flathead.flatten :as flat]
             [solita.common.maybe :as maybe]
@@ -18,7 +19,8 @@
             [solita.etp.service.concurrent :as concurrent]
             [solita.etp.service.liite :as liite-service]
             [solita.etp.service.csv :as csv-service])
-  (:import (java.time Instant)))
+  (:import (java.time Instant)
+           (clojure.lang ExceptionInfo)))
 
 (db/require-queries 'valvonta-kaytto)
 
@@ -252,7 +254,15 @@
           toimenpide-id (:id toimenpide)]
       (insert-toimenpide-osapuolet! tx valvonta-id toimenpide-id)
       (case (-> toimenpide :type-id toimenpide/type-key)
-        :closed (asha/close-case! whoami valvonta-id toimenpide)
+        :closed (try
+                  (asha/close-case! whoami valvonta-id toimenpide)
+                  (catch ExceptionInfo e
+                    (case (-> e ex-data :type)
+                      ;; The database transaction to close the case should run to completion
+                      ;; even when Asha does not agree to close it.
+                      :asha-request-failed
+                      (log/warn e "Could not close the case in Asha - will only close locally")
+                      (throw e))))
         (when (toimenpide/asha-toimenpide? toimenpide)
           (let [find-toimenpide-osapuolet (comp flatten (juxt find-toimenpide-henkilot find-toimenpide-yritykset))
                 osapuolet (find-toimenpide-osapuolet tx (:id toimenpide))]


### PR DESCRIPTION
A known reason for error when asking Asha to close a case is that the case has already been closed in Asha. This has prevented pääkäyttäjä from closing cases in ETP. This change makes the close command progress to completion even if Asha gives an error to the request to close the case.