### PR TITLE
AE-1786 Fix Template schema for oikeellisuuden valvonta

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/valvonta_kaytto.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta_kaytto.clj
@@ -47,7 +47,7 @@
     ["/templates"
      {:conflicting true
       :get         {:summary   "Hae käytönvalvonnan asiakirjapohjat."
-                    :responses {200 {:body [valvonta-schema/Template]}}
+                    :responses {200 {:body [valvonta-kaytto-schema/Template]}}
                     :access    rooli-service/paakayttaja?
                     :handler   (fn [{:keys [db]}]
                                  (r/response (valvonta-service/find-templates db)))}}]

--- a/etp-backend/src/main/clj/solita/etp/schema/valvonta.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/valvonta.clj
@@ -9,8 +9,7 @@
 (def Template
   (assoc common-schema/Luokittelu
     :toimenpidetype-id common-schema/Key
-    :language schema/Str
-    :tiedoksi schema/Bool))
+    :language schema/Str))
 
 (def Valvoja
   "Any kayttaja who can be valvoja"

--- a/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
@@ -2,6 +2,7 @@
   (:require [schema.core :as schema]
             [solita.etp.schema.common :as common-schema]
             [solita.etp.schema.geo :as geo-schema]
+            [solita.etp.schema.valvonta :as valvonta-schema]
             [schema-tools.core :as schema-tools]))
 
 (defn complete-valvonta-related-schema [schema]
@@ -37,6 +38,10 @@
    :deadline-date (schema/maybe common-schema/Date)
    :template-id   (schema/maybe common-schema/Key)
    :description   (schema/maybe schema/Str)})
+
+(def Template
+  (assoc valvonta-schema/Template
+         :tiedoksi schema/Bool))
 
 (def OsapuoliBase
   (schema-tools/merge {:rooli-id                 (schema/maybe common-schema/Key)


### PR DESCRIPTION
The solita.etp.schema.valvonta/Template schema was common for oikeellisuuden valvonta and käytönvalvonta, which means that adding the :tiedoksi member for käytönvalvonta would break things for oikeellisuuden valvonta.

This change splits things so that solita.etp.schema.valvonta/Template is reverted to its old state, and
solita.etp.schema.valvonta-kaytto/Template has the additions for käytönvalvonta.