### PR TITLE
AE-1794 Add mechanism to close käytönvalvonta, bypassing Asha

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/valvonta_kaytto_toimenpiteet.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta_kaytto_toimenpiteet.clj
@@ -34,6 +34,21 @@
                                (valvonta-service/add-toimenpide! db aws-s3-client whoami id body))
                             [{:constraint :toimenpide-vk-valvonta-id-fkey
                               :response   404}]))}}]
+   ["/bypassing-asha"
+    {:conflicting true
+     :post {:summary    "Lisää käytönvalvonnan toimenpide ilman AsHa -integraatiota."
+            :access     rooli-service/paakayttaja?
+            :parameters {:path {:id common-schema/Key}
+                         :body kaytto-schema/ToimenpideAdd}
+            :responses  {201 {:body common-schema/Id}
+                         404 common-schema/ConstraintError}
+            :handler    (fn [{{{:keys [id]} :path :keys [body]}
+                              :parameters :keys [db uri]}]
+                          (api-response/with-exceptions
+                            #(api-response/created uri
+                               (valvonta-service/add-toimenpide-bypassing-asha! db id body))
+                            [{:constraint :toimenpide-vk-valvonta-id-fkey
+                              :response   404}]))}}]
    ["/henkilot/:henkilo-id/preview"
     {:conflicting true
      :post        {:summary    "Henkilö-osapuolen toimenpiteen esikatselu"

--- a/etp-backend/src/main/clj/solita/etp/api/valvonta_kaytto_toimenpiteet.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/valvonta_kaytto_toimenpiteet.clj
@@ -34,21 +34,6 @@
                                (valvonta-service/add-toimenpide! db aws-s3-client whoami id body))
                             [{:constraint :toimenpide-vk-valvonta-id-fkey
                               :response   404}]))}}]
-   ["/bypassing-asha"
-    {:conflicting true
-     :post {:summary    "Lisää käytönvalvonnan toimenpide ilman AsHa -integraatiota."
-            :access     rooli-service/paakayttaja?
-            :parameters {:path {:id common-schema/Key}
-                         :body kaytto-schema/ToimenpideAdd}
-            :responses  {201 {:body common-schema/Id}
-                         404 common-schema/ConstraintError}
-            :handler    (fn [{{{:keys [id]} :path :keys [body]}
-                              :parameters :keys [db uri]}]
-                          (api-response/with-exceptions
-                            #(api-response/created uri
-                               (valvonta-service/add-toimenpide-bypassing-asha! db id body))
-                            [{:constraint :toimenpide-vk-valvonta-id-fkey
-                              :response   404}]))}}]
    ["/henkilot/:henkilo-id/preview"
     {:conflicting true
      :post        {:summary    "Henkilö-osapuolen toimenpiteen esikatselu"

--- a/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
@@ -37,7 +37,8 @@
   {:type-id       common-schema/Key
    :deadline-date (schema/maybe common-schema/Date)
    :template-id   (schema/maybe common-schema/Key)
-   :description   (schema/maybe schema/Str)})
+   :description   (schema/maybe schema/Str)
+   (schema/optional-key :bypass-asha) schema/Bool})
 
 (def Template
   (assoc valvonta-schema/Template
@@ -64,16 +65,18 @@
 (def YritysStatus Yritys)
 
 (def Toimenpide
-  (assoc ToimenpideAdd
-    :id common-schema/Key
-    :diaarinumero (schema/maybe schema/Str)
-    :author common-schema/Kayttaja
-    :create-time common-schema/Instant
-    :publish-time common-schema/Instant
-    :filename (schema/maybe schema/Str)
-    :valvonta-id common-schema/Key
-    :henkilot [Henkilo]
-    :yritykset [Yritys]))
+  (-> ToimenpideAdd
+      (dissoc (schema/optional-key :bypass-asha))
+      (assoc
+       :id common-schema/Key
+       :diaarinumero (schema/maybe schema/Str)
+       :author common-schema/Kayttaja
+       :create-time common-schema/Instant
+       :publish-time common-schema/Instant
+       :filename (schema/maybe schema/Str)
+       :valvonta-id common-schema/Key
+       :henkilot [Henkilo]
+       :yritykset [Yritys])))
 
 (def LastToimenpide
   (schema-tools/select-keys Toimenpide

--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/toimenpide.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/toimenpide.clj
@@ -19,6 +19,7 @@
   (contains? type-key-set (-> toimenpide :type-id type-key)))
 
 (def case-open? (partial type? :case))
+(def case-close? (partial type? :closed))
 (def send-tiedoksi? (partial type? :rfi-request))
 
 (def asha-toimenpide?


### PR DESCRIPTION
To deal with cases where states of ETP and Asha diverge, this change adds an API that processes a case-closing toimenpide without contacting Asha at all. This can be necessary e.g. if pääkäyttäjä manually closes the case in Asha for some reason.

The API is kept similar to the usual one used POSTing toimenpiteitä, but there is a check that only permits toimenpide of type :closed.