### PR TITLE
AE-1781 Add newly required attribute to muutoshistory of kayttaja

### DIFF
--- a/etp-backend/src/main/sql/solita/etp/db/kayttaja.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/kayttaja.sql
@@ -27,6 +27,7 @@ select k.id,
        k.virtu$organisaatio,
        k.henkilotunnus,
        k.modifytime,
+       k.valvoja,
        fullname(modifier) modifiedby_name
 from
   audit.kayttaja k


### PR DESCRIPTION
AE-1704 extended kayttaja by adding the valvoja boolean to indicate if the kayttaja should be included in selectors of valvojat. In the implementation, a small omission was that the history feature did not include this new attribute.