### PR TITLE
AE-1802 The relaxed rakennustunnus has to be optional

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/schema/energiatodistus_history.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/energiatodistus_history.clj
@@ -16,7 +16,7 @@
    :form-history [AuditEvent]})
 
 (defn- et-schema->et-history-schema [s]
-  (assoc-in s [:perustiedot :rakennustunnus] schema/Str))
+  (assoc-in s [:perustiedot :rakennustunnus] (schema/maybe schema/Str)))
 
 (def Energiatodistus2018
   (et-schema->et-history-schema energiatodistus-schema/Energiatodistus2018))


### PR DESCRIPTION
The previous fix to AE-1802 removed the formatting constraint from rakennustunnus in ET history, but it accidentally added a requirement for rakennustunnus to be present as a string.