### PR TITLE
Move solita.etp.service.rooli/system to kayttaja service

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/laatija.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/laatija.clj
@@ -8,6 +8,7 @@
             [solita.etp.schema.laatija :as laatija-schema]
             [solita.etp.service.laatija :as laatija-service]
             [solita.etp.service.kayttaja-laatija :as kayttaja-laatija-service]
+            [solita.etp.service.kayttaja :as kayttaja-service]
             [solita.etp.service.rooli :as rooli-service]
             [solita.etp.security :as security]))
 
@@ -129,7 +130,7 @@
   [["/laatijat"
     ["/patevyys-expiration-messages"
      {:middleware [[security/wrap-db-application-name
-                    (rooli-service/system :communication)]]
+                    (kayttaja-service/system-kayttaja :communication)]]
       :post       {:summary   "Käynnistä pätevyysmuistutusten lähetys"
                    :parameters
                    {:query {:months-before-expiration              schema/Int

--- a/etp-backend/src/main/clj/solita/etp/api/laskutus.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/laskutus.clj
@@ -3,12 +3,14 @@
             [ring.util.response :as r]
             [schema.core :as schema]
             [solita.etp.security :as security]
+            [solita.etp.service.kayttaja :as kayttaja-service]
             [solita.etp.service.laskutus :as laskutus-service]
             [solita.etp.service.concurrent :as concurrent]))
 
 (def routes
   [["/laskutus"
-    {:middleware [[security/wrap-db-application-name -2]]
+    {:middleware [[security/wrap-db-application-name
+                   (kayttaja-service/system-kayttaja :laskutus)]]
      :post       {:summary    "Käynnistä laskutusajo"
                   :parameters {:query {(schema/optional-key :dryrun) schema/Bool}}
                   :responses  {200 {:body nil}}

--- a/etp-backend/src/main/clj/solita/etp/service/kayttaja.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/kayttaja.clj
@@ -81,3 +81,7 @@
     (->> (kayttaja-db/select-kayttaja-history db {:id kayttaja-id})
          (map (db-row->kayttaja kayttaja-schema/KayttajaHistory)))
     (exception/throw-forbidden!)))
+
+(def system-kayttaja
+  {:communication -3
+   :laskutus -2})

--- a/etp-backend/src/main/clj/solita/etp/service/rooli.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/rooli.clj
@@ -30,7 +30,3 @@
 (defn rooli-key [rooli-id] (nth rooli-keys rooli-id))
 
 (def energiatodistus-reader? (some-fn laatija? paakayttaja? laskuttaja?))
-
-(def system
-  {:communication -3
-   :laskutus -2})

--- a/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
@@ -9,7 +9,7 @@
             [solita.etp.service.laatija :as service]
             [solita.etp.service.viesti :as viesti-service]
             [solita.etp.whoami :as test-whoami]
-            [solita.etp.service.rooli :as rooli-service])
+            [solita.etp.service.kayttaja :as kayttaja-service])
   (:import (java.time LocalDate ZoneId Instant)))
 
 (t/use-fixtures :each ts/fixture)
@@ -197,7 +197,7 @@
   (let [paakayttaja-id (kayttaja-test-data/insert-paakayttaja!)
         [id _] (laatija-test-data/generate-and-insert!)
         ^LocalDate now (LocalDate/now)
-        system-id (rooli-service/system :communication)
+        system-id (kayttaja-service/system-kayttaja :communication)
         options {:months-before-expiration 6 :fallback-window 5}]
     (service/update-laatija-by-id!
       ts/*db* id


### PR DESCRIPTION
It seems that the numbers in this map are kayttaja ids rather than rooli ids. Having them in kayttaja service makes code read more obvious what we are actually retrieving from the map.