### PR TITLE
Allow not verifying the signature in api/signed

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/security.clj
+++ b/etp-backend/src/main/clj/solita/etp/security.clj
@@ -65,6 +65,11 @@
               (merge {:headers {"WWW-Authenticate" (format "Basic realm=\"%s\""
                                                            realm)}})))))))
 
+(defn wrap-whoami-assume-verified-signature [handler]
+  (fn [req]
+    (handler (assoc req :whoami {:id (:presigned kayttaja-service/system-kayttaja)
+                                 :rooli -1}))))
+
 (defn wrap-whoami-from-signed [handler index-url key-map]
   (fn [req]
     (let [signed-url (str index-url (-> req :uri) "?" (-> req :query-string))]


### PR DESCRIPTION
In case CloudFront is there checking the signature, it also seems to trim it away from the query string. This means the backend here will not be able to verify it on its part.

This partially reverts commit
41ebff2da4240829efd6bf4368dcffd82d6a0b0a.