### PR TITLE
AE-1815 Better handling for a missing x-forwarded-for header

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/security.clj
+++ b/etp-backend/src/main/clj/solita/etp/security.clj
@@ -72,7 +72,7 @@
                                  :rooli -1}))))
 
 (defn first-address [x-forwarded-for]
-  (-> x-forwarded-for (str/split #"[\s,]+") first))
+  (some-> x-forwarded-for (str/split #"[\s,]+") first))
 
 (defn wrap-whoami-from-signed [handler index-url key-map]
   (fn [{:as req


### PR DESCRIPTION
Normally the backend runs behind trusted reverse proxies that add the x-forwarded-for header. In case this header is missing, the aineisto endpoints would fail on an unhandled exception. Should be better to explicitly require it.