### PR TITLE
Fix kayttaja muutoshistoria

### DIFF
--- a/etp-backend/src/main/sql/solita/etp/db/kayttaja.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/kayttaja.sql
@@ -30,7 +30,7 @@ select k.id,
        k.henkilotunnus,
        k.modifytime,
        k.valvoja,
-       k.organisaatio,
+       coalesce(k.organisaatio, '') as organisaatio,
        fullname(modifier) modifiedby_name
 from
   audit.kayttaja k


### PR DESCRIPTION
The main kayttaja API already replaces a nil organisaatio with an empty string. Let's do the same for their muutoshistoria as well.