### PR TITLE
AE-1812 Add some facilities for bilingual name search

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search.clj
@@ -65,7 +65,8 @@
     {:energiatodistus public-energiatodistus-schema/Energiatodistus2018}
     {:energiatodistus
      {:perustiedot
-      {:postinumero schema/Int}}}
+      {:nimi schema/Str
+       :postinumero schema/Int}}}
     geo-schema/Search))
 
 (defn- schema-contains? [key schema]
@@ -122,6 +123,10 @@
       (search-fields/field->db-column field-parts)
       (first computed-field))))
 
+(defn icontains-expression [search-schema _ field value]
+  [(str "0 != position(lower(?) in lower(" (field->sql field search-schema) "))")
+   (coerce-value! field value search-schema)])
+
 (defn infix-notation [search-schema operator field value]
   [(str (field->sql field search-schema) " " operator " ?")
    (coerce-value! field value search-schema)])
@@ -169,6 +174,7 @@
    "<=" infix-notation
    ">"  infix-notation
    "<"  infix-notation
+   "icontains" icontains-expression
    "like"  (globbing infix-notation)
    "ilike"  (globbing infix-notation)
    "not ilike" infix-notation

--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search_fields.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search_fields.clj
@@ -96,7 +96,9 @@
 (def computed-fields
   "Computed field consists of sql expression and value schema [sql, schema]"
   {:energiatodistus
-   {:lahtotiedot
+   {:perustiedot
+    {:nimi ["energiatodistus.pt$nimi_fi || '__' || energiatodistus.pt$nimi_fi" schema/Str]}
+    :lahtotiedot
     {:rakennusvaippa (deep/deep-merge ua-fields osuus-lampohaviosta-fields)}
     :tulokset
     {:kaytettavat-energiamuodot


### PR DESCRIPTION
- An icontains search predicate, as a simpler alternative to ilike
  - No need to pad with % signs
  - No special meaning for % either
- Computational perustiedot.nimi search field