### PR TITLE
Feature/ae 1845

### DIFF
--- a/etp-backend/Dockerfile
+++ b/etp-backend/Dockerfile
@@ -1,3 +1,12 @@
+# Build image
+FROM --platform=amd64 clojure:temurin-11-tools-deps-1.11.1.1257-alpine as builder
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+RUN clojure -M:uberjar
+
+
+# Production image
 FROM --platform=amd64 eclipse-temurin:11.0.18_10-jdk-jammy
 
 # LibreOffice installation
@@ -11,7 +20,7 @@ ln -s /usr/local/bin/libreoffice7.1 /usr/local/bin/libreoffice
 
 # The application
 COPY libreoffice/ /opt/etp/libreoffice/
-COPY target/etp-backend.jar /opt/etp/target/
+COPY --from=builder /usr/src/app/target/etp-backend.jar /opt/etp/target/
 COPY start.sh /opt/etp/
 
 WORKDIR /opt/etp

--- a/etp-backend/Dockerfile
+++ b/etp-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM --platform=amd64 eclipse-temurin:11.0.18_10-jdk-jammy
 
 # LibreOffice installation
 RUN apt-get update && \

--- a/etp-backend/build-docker-image.sh
+++ b/etp-backend/build-docker-image.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -e
 
-rm -rf target
-clojure -A:uberjar
 docker build . --tag etp-backend

--- a/etp-db/Dockerfile
+++ b/etp-db/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM --platform=amd64 eclipse-temurin:11.0.18_10-jdk-jammy
 
 COPY target /target
 COPY db.sh /


### PR DESCRIPTION
* Switched the Docker base image from openjdk:11 to eclipse-temurin:11, with a pinned version, Ubuntu 22 based image
* For backend build added a separate build image where the uberjar is built and removed the uberjar building from the script
* Didn't touch the db build scripts as they were a bit scary looking