### PR TITLE
AE-1835: Allow 10 aineisto permit ip addresses

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/kayttaja.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/kayttaja.clj
@@ -93,7 +93,8 @@
                           #(api-response/ok|not-found
                             (aineisto-service/set-kayttaja-aineistot! db id body)
                             (str "Käyttäjä " id " does not exist"))
-                          [{:type :foreign-key-violation :response 400}]))}}]]]
+                          [{:type :foreign-key-violation :response 400}
+                           {:type :too-many-permits :response 400}]))}}]]]
    ["/roolit"
     {:get {:summary    "Hae roolit -luokittelu"
            :responses  {200 {:body [rooli-schema/Rooli]}}

--- a/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
@@ -40,11 +40,14 @@
 
 (defn set-kayttaja-aineistot! [db kayttaja-id aineistot]
   ;; Only 10 ip addresses are allowed to access the aineistot
-  (when (<= (count aineistot) 10)
-    (jdbc/with-db-transaction [db db]
-      ;; Clear out any previously existing entries from the user
-      (let [_ (aineisto-db/delete-kayttaja-access! db {:kayttaja-id kayttaja-id})]
-        ;; Fill in new ones
-        (doseq [aineisto aineistot]
-          (set-access! db kayttaja-id aineisto))
-        1))))
+  (when (> (count aineistot) 10)
+    (throw (ex-info "Maximum of 10 permits allowed"
+                    {:type :too-many-permits})))
+
+  (jdbc/with-db-transaction [db db]
+    ;; Clear out any previously existing entries from the user
+    (let [_ (aineisto-db/delete-kayttaja-access! db {:kayttaja-id kayttaja-id})]
+      ;; Fill in new ones
+      (doseq [aineisto aineistot]
+        (set-access! db kayttaja-id aineisto))
+      1)))

--- a/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
@@ -39,10 +39,12 @@
                                              :ip-address nil}))
 
 (defn set-kayttaja-aineistot! [db kayttaja-id aineistot]
-  (jdbc/with-db-transaction [db db]
-    ;; Clear out any previously existing entries from the user
-    (let [res (aineisto-db/delete-kayttaja-access! db {:kayttaja-id kayttaja-id})]
-      ;; Fill in new ones
-      (doseq [aineisto aineistot]
-        (set-access! db kayttaja-id aineisto))
-      1)))
+  ;; Only 10 ip addresses are allowed to access the aineistot
+  (when (<= (count aineistot) 10)
+    (jdbc/with-db-transaction [db db]
+      ;; Clear out any previously existing entries from the user
+      (let [_ (aineisto-db/delete-kayttaja-access! db {:kayttaja-id kayttaja-id})]
+        ;; Fill in new ones
+        (doseq [aineisto aineistot]
+          (set-access! db kayttaja-id aineisto))
+        1))))

--- a/etp-backend/src/main/sql/solita/etp/db/aineisto.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/aineisto.sql
@@ -3,15 +3,13 @@ select
   aineisto_id, valid_until, ip_address
 from kayttaja_aineisto
 where kayttaja_id = :kayttaja-id and
+--       Null check pois?
       (:ip-address::inet is null or (:ip-address)::inet <<= ip_address::inet) and
       valid_until > now();
 
 -- name: insert-kayttaja-aineisto!
 insert into kayttaja_aineisto (kayttaja_id, aineisto_id, valid_until, ip_address)
-values (:kayttaja-id, :aineisto-id, :valid-until, ((:ip-address)::inet)::text)
-on conflict (kayttaja_id, aineisto_id) do update set
-  valid_until = excluded.valid_until,
-  ip_address = excluded.ip_address;
+values (:kayttaja-id, :aineisto-id, :valid-until, ((:ip-address)::inet)::text);
 
 -- name: delete-kayttaja-aineisto!
 delete from kayttaja_aineisto

--- a/etp-backend/src/main/sql/solita/etp/db/aineisto.sql
+++ b/etp-backend/src/main/sql/solita/etp/db/aineisto.sql
@@ -3,7 +3,6 @@ select
   aineisto_id, valid_until, ip_address
 from kayttaja_aineisto
 where kayttaja_id = :kayttaja-id and
---       Null check pois?
       (:ip-address::inet is null or (:ip-address)::inet <<= ip_address::inet) and
       valid_until > now();
 

--- a/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
@@ -1,0 +1,22 @@
+(ns solita.etp.service.aineisto-test
+  (:require [solita.etp.service.aineisto :as aineisto]
+            [solita.etp.test-system :as ts]
+            [clojure.test :as t])
+  (:import (java.time Instant)))
+
+(t/use-fixtures :each ts/fixture)
+
+(def test-aineisto
+  (repeatedly (constantly {:aineisto-id 1,
+                           :valid-until (Instant/now),
+                           :ip-address  "192.168.56.22"})))
+
+(t/deftest set-kayttaja-aineistot!-test
+  (t/testing "Maximum of ten aineistot is allowed"
+    ;; Mock the actual database inserts as they are not necessary for these tests
+    (with-redefs [aineisto/set-access! (fn [_ _ _] true)]
+      (t/testing "11 results in nil"
+        (t/is (nil? (aineisto/set-kayttaja-aineistot! ts/*db* 1 (take 11 test-aineisto)))))
+      (t/testing "10 is allowed, return value 1 tells inserts succeeded"
+        (t/is (= 1
+                 (aineisto/set-kayttaja-aineistot! ts/*db* 1 (take 10 test-aineisto))))))))

--- a/etp-db/src/main/sql/migration/v5-release-1.1/v5.35-remove-kayttaja_aineisto-constraint.sql
+++ b/etp-db/src/main/sql/migration/v5-release-1.1/v5.35-remove-kayttaja_aineisto-constraint.sql
@@ -1,0 +1,2 @@
+alter table kayttaja_aineisto
+    drop constraint kayttaja_aineisto_kayttaja_id_aineisto_id_key;


### PR DESCRIPTION
* Remove unique constraint from kayttaja_aineisto table
* remove unnecessary on conflict clause from insert-kayttaja-aineisto! as the existing rows for the user are already deleted before the insert
* Add maximum limit of aineisto permits and set it to 10