### PR TITLE
Clj kondo unresolved namespace fix

### DIFF
--- a/etp-backend/.clj-kondo/config.edn
+++ b/etp-backend/.clj-kondo/config.edn
@@ -1,0 +1,3 @@
+{:ns-groups    [{:pattern ".*-db$" :name db-namespaces}]
+ :linters
+ {:unresolved-namespace {:exclude [db-namespaces]}}}

--- a/etp-backend/deps.edn
+++ b/etp-backend/deps.edn
@@ -77,5 +77,5 @@
                                 "target/etp-backend.jar"]}
            :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.2.1017"}}
                       :main-opts ["-m" "antq.core"]}
-           :lint {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.03.17"}}
+           :lint {:extra-deps {clj-kondo/clj-kondo {:mvn/version "2023.04.14"}}
                   :main-opts ["-m" "clj-kondo.main" "--lint" "src"]}}}

--- a/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
@@ -15,7 +15,7 @@
   (t/testing "Maximum of ten aineistot is allowed"
     ;; Mock the actual database inserts as they are not necessary for these tests
     (with-redefs [aineisto/set-access! (fn [_ _ _] true)]
-      (t/testing "11 results in nil"
+      (t/testing "11 results in an exception"
         (t/is (thrown? Exception (aineisto/set-kayttaja-aineistot! ts/*db* 1 (take 11 test-aineisto)))))
       (t/testing "10 is allowed, return value 1 tells inserts succeeded"
         (t/is (= 1


### PR DESCRIPTION
- Update clj-kondo so it supports namespace groups configuration for unresolved namespace linter
- Add clj-kondo configuration that configures that linter to ignore unresolved namespaces that end in -db (generated by jeesql)