### PR TITLE
AE-1880: Remove two parameter arity version of solita.etp.service.liite/delete-liite! which allowed deletion without permission check

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/liite.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/liite.clj
@@ -75,13 +75,10 @@
     (assert-permission! db whoami (:energiatodistus-id liite))
     (assoc liite :content (file-service/find-file aws-s3-client (file-key liite-id)))))
 
-(defn delete-liite!
-  ([db liite-id]
-   (liite-db/delete-liite! db {:id liite-id}))
-  ([db whoami liite-id]
-    (let [energiatodistus-id (some->> {:id liite-id}
-                                      (liite-db/select-liite db)
-                                      first
-                                      :energiatodistus-id)]
-      (assert-permission! db whoami energiatodistus-id)
-      (delete-liite! db liite-id))))
+(defn delete-liite! [db whoami liite-id]
+  (let [energiatodistus-id (some->> {:id liite-id}
+                                    (liite-db/select-liite db)
+                                    first
+                                    :energiatodistus-id)]
+    (assert-permission! db whoami energiatodistus-id)
+    (liite-db/delete-liite! db {:id liite-id})))

--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_oikeellisuus.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_oikeellisuus.clj
@@ -296,7 +296,7 @@
     db id (assoc liite :vo-toimenpide-id toimenpide-id)))
 
 (defn delete-liite! [db whoami id toimenpide-id liite-id]
-  (liite-service/delete-liite! db liite-id))
+  (liite-service/delete-liite! db whoami liite-id))
 
 (defn- update-toimenpide-row! [db toimenpide-id toimenpide]
   (first (db/with-db-exception-translation


### PR DESCRIPTION
AE-1880: Remove two parameter arity version of solita.etp.service.liite/delete-liite! which allowed deletion without permission check

- This allowed other laatija's than the owner of the energiatodistus to delete files
- Added a test that checks that the permission assertion works here