### PR TITLE
AE-1886: Update commons-io

### DIFF
--- a/etp-backend/deps.edn
+++ b/etp-backend/deps.edn
@@ -56,7 +56,7 @@
         org.apache.axis/axis {:mvn/version "1.4"}
         org.apache.axis/axis-ant {:mvn/version "1.4"}
         javax.xml/webservices-api {:mvn/version "1.4"}
-        commons-io/commons-io {:mvn/version "1.4"}
+        commons-io/commons-io {:mvn/version "2.11.0"}
         com.sun.xml.ws/webservices-rt {:mvn/version "2.0"
                                        :exclusions ["javax.xml/webservices-api"]}
         commons-discovery/commons-discovery {:mvn/version "0.5"}}


### PR DESCRIPTION
Not worth it to remove the dependency even if we could replace the usage with something else, as so many dependencies bring this as a transitive dependency. By removing it we only get an old vulnerable version as a transitive dependency.