### PR TITLE
Update development experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           cli: 1.11.1.1273
       - name: Install Libreoffice
-        run: sudo apt-get install libreoffice
+        run: sudo apt-get update && sudo apt-get install libreoffice
       - name: Docker Compose
         working-directory: docker
         run: ./start.sh

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ For Ubuntu:
 
 https://clojure.org/guides/getting_started#_installation_on_linux
 
+### LibreOffice
+Install LibreOffice
+
+For MacOS:
+
+    brew install libreoffice
+    ln -s /opt/homebrew/bin/soffice /opt/homebrew/bin/libreoffice
+
 Starting the development environment
 --------------------------------
 
@@ -64,7 +72,7 @@ The application can be also started from the command line with the following
 command:
 
     cd etp-backend
-    clojure -m solita.etp.core
+    clojure -M:dev -m solita.etp.core
 
 Tests can be run (parallel) with
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 mkdir -p smtp/received-emails
 find sftp/ssh -iname "*_key" -exec chmod 600 {} \;

--- a/etp-backend/src/test/clj/solita/etp/test_system.clj
+++ b/etp-backend/src/test/clj/solita/etp/test_system.clj
@@ -2,7 +2,6 @@
   (:require [clojure.string :as str]
             [clojure.java.jdbc :as jdbc]
             [integrant.core :as ig]
-            [solita.common.jdbc :as common-jdbc]
             [solita.etp.config :as config]
             [solita.etp.db]
             [solita.etp.aws-s3-client]


### PR DESCRIPTION
Add LibreOffice as a dependency.

Update the command for running the server.

Quote paths in start script to prevent word splitting when there are spaces in the path.

Remove unused import.

Update apt-get cache before install.