### PR TITLE
Implement searching by lämmitysjärjestelmä

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search.clj
@@ -201,7 +201,11 @@
     (concat [(str "((" fi-sql ")" logical-op "(" sv-sql "))")]
             fi-values sv-values)))
 
-(defn- expand-multiplexed-expression [formatter search-schema predicate field multiplexed-field & values]
+(defn- expand-multiplexed-expression
+  "Expands expressions for fields where the actual db field has suffixes -1 and -2 somewhere in the search path, such as
+  energiatodistus.lahtotiedot.lammitys.lammitysmuoto(-1|-2).id. Could be modified to use with other suffixes as well,
+  such as language options"
+  [formatter search-schema predicate field multiplexed-field & values]
   (let [logical-op "or"
         [sql-1 & values-1] (apply formatter search-schema predicate (str multiplexed-field "-1" (last (str/split field (re-pattern multiplexed-field) 2))) values)
         [sql-2 & values-2] (apply formatter search-schema predicate (str multiplexed-field "-2" (last (str/split field (re-pattern multiplexed-field) 2))) values)]

--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search_fields.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search_fields.clj
@@ -6,7 +6,6 @@
             [solita.etp.schema.energiatodistus :as energiatodistus-schema]
             [solita.etp.schema.laatija :as laatija-schema]
             [clojure.string :as str]
-            [schema.core :as schema]
             [flathead.deep :as deep]
             [solita.etp.schema.common :as common-schema])
   (:import (clojure.lang IPersistentVector)))
@@ -79,7 +78,7 @@
 
 (def ^:private ua-total-sql
   (->> ua-fields
-       (map (fn [[key value]] (-> value :UA first)))
+       (map (fn [[_ value]] (-> value :UA first)))
        (str/join " + ")
        (str "energiatodistus.lt$rakennusvaippa$kylmasillat_ua + ")))
 

--- a/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
@@ -39,7 +39,7 @@
             response-body (j/read-value (:body response) j/keyword-keys-object-mapper)]
         (t/is (= (:status response) 200))
         (t/is (= (count response-body) 4))))
-    (t/testing "Haku löytää energiatodisukset, joissa kumpi tahansa lämmitysmuoto on haettu"
+    (t/testing "Haku löytää energiatodistukset, joissa kumpi tahansa lämmitysmuoto on haettu"
       (let [response (ts/handler (-> (mock/request :get "/api/private/energiatodistukset?where=%5B%5B%5B%22%3D%22%2C%22energiatodistus.lahtotiedot.lammitys.lammitysmuoto.id%22%2C1%5D%5D%5D")
                                   (test-kayttajat/with-virtu-user)
                                   (mock/header "Accept" "application/json")))

--- a/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
@@ -1,0 +1,51 @@
+(ns solita.etp.energiatodistus-search-api-test
+  (:require
+    [clojure.test :as t]
+    [jsonista.core :as j]
+    [ring.mock.request :as mock]
+    [solita.etp.test-data.kayttaja :as test-kayttajat]
+    [solita.etp.test-system :as ts]
+    [solita.etp.test-data.energiatodistus :as energiatodistus-test-data]
+    [solita.etp.test-data.laatija :as laatija-test-data]
+    [solita.etp.service.energiatodistus-search-test :as energiatodistus-search-test]))
+
+(t/use-fixtures :each ts/fixture)
+
+(t/deftest search-energiatodistus
+  (laatija-test-data/insert! (laatija-test-data/generate-adds 1))
+  (test-kayttajat/insert-virtu-paakayttaja!)
+  (let [energiatodistus-adds (concat
+                               (map (fn [et]
+                                      (-> et
+                                          (assoc-in [:lahtotiedot :lammitys :lammitysmuoto-1 :id] 1)
+                                          (assoc-in [:lahtotiedot :lammitys :lammitysmuoto-2 :id] 2)))
+                                    (energiatodistus-test-data/generate-adds 1 2018 true))
+                               (map (fn [et]
+                                      (-> et
+                                          (assoc-in [:lahtotiedot :lammitys :lammitysmuoto-1 :id] 2)
+                                          (assoc-in [:lahtotiedot :lammitys :lammitysmuoto-2 :id] 1)))
+                                    (energiatodistus-test-data/generate-adds 1 2018 true))
+                               (map (fn [et]
+                                      (-> et
+                                          (assoc-in [:lahtotiedot :lammitys :lammitysmuoto-1 :id] 3)
+                                          (assoc-in [:lahtotiedot :lammitys :lammitysmuoto-2 :id] 4)))
+                                    (energiatodistus-test-data/generate-adds 2 2018 true)))
+        ids (energiatodistus-test-data/insert! energiatodistus-adds 1)]
+    (energiatodistus-search-test/sign-energiatodistukset! (map vector (repeatedly (constantly 1)) ids))
+    (t/testing "Haku ilman parametrejä palauttaa kaikki energiatodisukset"
+      (let [response (ts/handler (-> (mock/request :get "/api/private/energiatodistukset")
+                                              (test-kayttajat/with-virtu-user)
+                                              (mock/header "Accept" "application/json")))
+            response-body (j/read-value (:body response) j/keyword-keys-object-mapper)]
+        (t/is (= (:status response) 200))
+        (t/is (= (count response-body) 4))))
+    (t/testing "Haku löytää energiatodisukset, joissa kumpi tahansa lämmitysmuoto on haettu"
+      (let [response (ts/handler (-> (mock/request :get "/api/private/energiatodistukset?where=%5B%5B%5B%22%3D%22%2C%22energiatodistus.lahtotiedot.lammitys.lammitysmuoto.id%22%2C1%5D%5D%5D")
+                                  (test-kayttajat/with-virtu-user)
+                                  (mock/header "Accept" "application/json")))
+            response-body (j/read-value (:body response) j/keyword-keys-object-mapper)]
+        (t/is (= (:status response) 200))
+        (t/is (= (count response-body) 2))
+        (t/is (every? (fn [et] (or (= (->> et :lahtotiedot :lammitys :lammitysmuoto-1 :id) 1)
+                                   (= (->> et :lahtotiedot :lammitys :lammitysmuoto-2 :id) 1)))
+                      response-body))))))

--- a/etp-backend/src/test/clj/solita/etp/test_data/kayttaja.clj
+++ b/etp-backend/src/test/clj/solita/etp/test_data/kayttaja.clj
@@ -1,5 +1,6 @@
 (ns solita.etp.test-data.kayttaja
-  (:require [solita.etp.test-system :as ts]
+  (:require [ring.mock.request :as mock]
+            [solita.etp.test-system :as ts]
             [solita.etp.test-data.generators :as generators]
             [solita.etp.schema.kayttaja :as kayttaja-schema]
             [solita.etp.service.kayttaja :as kayttaja-service]
@@ -58,3 +59,15 @@
                         }))
        insert!
        first))
+(def access-token
+  "eyJraWQiOiJ0ZXN0LWtpZCIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiJwYWFrYXl0dGFqYUBzb2xpdGEuZmkiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6Im9wZW5pZCIsImF1dGhfdGltZSI6MTU4MzIzMDk2OSwiaXNzIjoiaHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3NvbGl0YS9ldHAtY29yZS9mZWF0dXJlL0FFLTQzLWF1dGgtaGVhZGVycy1oYW5kbGluZy9ldHAtYmFja2VuZC9zcmMvbWFpbi9yZXNvdXJjZXMiLCJleHAiOjE4OTM0NTYwMDAsImlhdCI6MTU4MzQxMzQyNCwidmVyc2lvbiI6MiwianRpIjoiNWZkZDdhMjktN2VlYS00ZjNkLWE3YTYtYzIyODQyNmY2MTJiIiwiY2xpZW50X2lkIjoidGVzdC1jbGllbnRfaWQiLCJ1c2VybmFtZSI6InRlc3QtdXNlcm5hbWUifQ.PY5_jWcdxhCyn2EpFpss7Q0R3_xH1PvHi4mxDLorpppHnciGT2kFLeutebi7XeLtTYwmttTxxg2tyUyX0_UF7zj_P-tdq-kZQlud1ENmRaUxLXO5mTFKXD7zPb6BPFNe0ewRQ7Uuv3lDk_IxOf-6i86VDYB8luyesEXq7ra4S4l8akFodW_QYBSZQnUva_CVyzsTNcmgGTyrz2NI6seT1x6Pt1uFdYI97FHKlCCWVL1Z042omfujfta8j8XkTWdhKf3dfsHRWjrw31xqOkgD7uwPKcrC0U-wIj3U0uX0Rz2Tk4T-kIq4XTkKttYpkJqOmMFAYuhk6MDjfRkPWBZhUA")
+
+(def oidc-data "eyJ0eXAiOiJKV1QiLCJraWQiOiJ0ZXN0LWtpZCIsImFsZyI6IlJTMjU2IiwiaXNzIjoidGVzdC1pc3MiLCJjbGllbnQiOiJ0ZXN0LWNsaWVudCIsInNpZ25lciI6InRlc3Qtc2lnbmVyIiwiZXhwIjoxODkzNDU2MDAwfQ.eyJzdWIiOiJwYWFrYXl0dGFqYUBzb2xpdGEuZmkiLCJjdXN0b206VklSVFVfbG9jYWxJRCI6InZ2aXJrYW1pZXMiLCJjdXN0b206VklSVFVfbG9jYWxPcmciOiJ0ZXN0aXZpcmFzdG8uZmkiLCJ1c2VybmFtZSI6InRlc3QtdXNlcm5hbWUiLCJleHAiOjE4OTM0NTYwMDAsImlzcyI6InRlc3QtaXNzIn0.BfuDVOFUReiJd6N05Re6affps_47AA0F5o-g6prmXgAnk4lB1S3k9RpovCFU3-R5Zn0p38QTiwi5dENHCHaj1A6MGHHKeYd7vBZK0VquuBxlIQH-4k1MWLvpYnkK3yuEvfmbRb3jYspCA_4N-AF21cCyjd15RiuIawLCEM0Km1DRgLhXIBta6XCGSRwaRmrT7boDRMp7hUkYPpoakCahMC70sjyuvLE0pjAy1_S09g4SkboentI7WhfsfN4uAHbKy6ViVMfsnwVVvKsM8dXav_a-6PoNGywuUbi8nHt8c20KiB_AzAEYSqxbRX1YBd0UHlYS16LbLtMBTOctCBLDMg")
+
+(defn with-virtu-user
+  "Add virtu pääkäyttäjä user to ring-mock request"
+  [request]
+  (-> request
+      (mock/header "x-amzn-oidc-accesstoken" access-token)
+      (mock/header "x-amzn-oidc-identity" "paakayttaja@solita.fi")
+      (mock/header "x-amzn-oidc-data" oidc-data)))

--- a/etp-backend/src/test/clj/solita/etp/test_system.clj
+++ b/etp-backend/src/test/clj/solita/etp/test_system.clj
@@ -5,7 +5,8 @@
             [solita.etp.config :as config]
             [solita.etp.db]
             [solita.etp.aws-s3-client]
-            [solita.common.aws :as aws]))
+            [solita.common.aws :as aws]
+            [solita.etp.handler :as handler]))
 
 (def ^:dynamic *db* nil)
 (def ^:dynamic *admin-db* nil)
@@ -91,3 +92,9 @@
         (drop-db! management-db db-name)
         (drop-bucket! management-aws-s3-client)
         (ig/halt! management-system)))))
+
+(defn handler
+  "Get a handler to use with ring-mock requests to test the api"
+  [req]
+  ; Mimics real handler usage with test assets
+  (handler/handler (merge req {:db *db* :aws-s3-client *aws-s3-client*})))


### PR DESCRIPTION
Add options for searching by lämmitysjärjestelmä. Because there are two options for lämmitysjärjestelmä, added a capability to search from both fields at once, by splitting the search into both fields at once, similar to searching from multilangual fields.