### PR TITLE
Upgrade Flyway

### DIFF
--- a/etp-db/deps.edn
+++ b/etp-db/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src/main/clj" "src/main/sql" "src/main/resources"]
  :deps
  {org.clojure/clojure {:mvn/version "1.10.1"}
-  org.flywaydb/flyway-core {:mvn/version "6.2.0"}
+  org.flywaydb/flyway-core {:mvn/version "9.21.1"}
   org.postgresql/postgresql {:mvn/version "42.2.9"}
   ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}
  :aliases {:test {:extra-paths ["src/test/sql"]}

--- a/etp-db/src/main/clj/solita/etp/db/flywaydb.clj
+++ b/etp-db/src/main/clj/solita/etp/db/flywaydb.clj
@@ -38,8 +38,8 @@
   "Add ApplicationName to query parameters of the given url.
 
   Example:
-  http://localhost:5763/db => http://localhost:5736?ApplicationName=0@database.etp
-  http://localhost:5763/db?other_param=value => http://localhost:5736?ApplicationName=0@database.etp&other_param=value"
+  http://localhost:5763/db => http://localhost:5763/db?ApplicationName=0@database.etp
+  http://localhost:5763/db?other_param=value => http://localhost:5763/db?ApplicationName=0@database.etp&other_param=value"
   [url]
   (let [[base-url existing-query-string] (str/split url #"\?" 2)]
     (->> ["ApplicationName=0@database.etp" existing-query-string]

--- a/etp-db/src/main/clj/solita/etp/db/flywaydb.clj
+++ b/etp-db/src/main/clj/solita/etp/db/flywaydb.clj
@@ -34,16 +34,19 @@
 (defn env [name default]
   (or (System/getenv name) default))
 
+(defn- add-application-name
+  "Add application to query parameters of the given url."
+  [url]
+  (let [[base-url existing-query-string] (str/split url #"\?" 2)]
+    (->> ["ApplicationName=0@database.etp" existing-query-string]
+         (remove nil?)
+         (str/join "&")
+         (str base-url "?"))))
+
 (defn read-configuration []
-  (let [url (env "DB_URL" "jdbc:postgresql://localhost:5432/postgres")
-        existing-query (-> url (str/split #"\?" 2) (get 1))
-        url-with-app-name (->> ["ApplicationName=0@database.etp" existing-query]
-                               (remove nil?)
-                               (str/join "&")
-                               (str url "?"))]
-    {:user     (env "DB_USER" "etp")
-     :password (env "DB_PASSWORD" "etp")
-     :url      url-with-app-name}))
+  {:user     (env "DB_USER" "etp")
+   :password (env "DB_PASSWORD" "etp")
+   :url      (-> (env "DB_URL" "jdbc:postgresql://localhost:5432/postgres") add-application-name)})
 
 (defn run [args]
   (let [command (str/trim (or (first args) "<empty string>"))

--- a/etp-db/src/main/clj/solita/etp/db/flywaydb.clj
+++ b/etp-db/src/main/clj/solita/etp/db/flywaydb.clj
@@ -35,7 +35,11 @@
   (or (System/getenv name) default))
 
 (defn- add-application-name
-  "Add application to query parameters of the given url."
+  "Add ApplicationName to query parameters of the given url.
+
+  Example:
+  http://localhost:5763/db => http://localhost:5736?ApplicationName=0@database.etp
+  http://localhost:5763/db?other_param=value => http://localhost:5736?ApplicationName=0@database.etp&other_param=value"
   [url]
   (let [[base-url existing-query-string] (str/split url #"\?" 2)]
     (->> ["ApplicationName=0@database.etp" existing-query-string]

--- a/etp-db/src/main/sql/migration/beforeMigrate.sql
+++ b/etp-db/src/main/sql/migration/beforeMigrate.sql
@@ -1,1 +1,0 @@
-set application_name = '0@database.etp';


### PR DESCRIPTION
In 9.1.4 Flyway changed to use transactional locks, but it causes
migrations to freeze. Reverted to old default.

In 9.19.0 something breaks. Audit tables create a log of added kayttaja
entries. The audit log try to use the function current_kayttaja_id(),
which relies on "application name" being set. It's set in
beforeMigration.sql, but for some reason it doesn't work anymore. The
script gets executed, so maybe there are multiple connections? Added
ApplicationName to connection url to get around the problem.