### PR TITLE
Add tests and documentation for log-toimenpide! in asha

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_oikeellisuus/asha.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_oikeellisuus/asha.clj
@@ -146,7 +146,7 @@
                                        :contact              (osapuoli->contact laatija)}
                    :document          (toimenpide-type->document (:type-id toimenpide))}
    :rfi-order     {:identity          {:case              {:number (:diaarinumero toimenpide)}
-                                       :processing-action {:name-identity "Käsittely"}}
+                                       :processing-action {:name-identity "Vireillepano"}}
                    :processing-action {:name                 "Kehotuksen antaminen"
                                        :reception-date       (java.time.Instant/now)
                                        :contacting-direction "SENT"

--- a/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
@@ -4,7 +4,7 @@
             [clojure.test :as t]
             [solita.etp.service.asha :as asha-service]
             [solita.etp.test-system :as ts]
-            [clostache.parser])
+            [clostache.parser :refer [render-resource]])
   (:import (java.nio.charset StandardCharsets)
            (java.time Instant)
            (java.util Base64)))
@@ -157,23 +157,17 @@
                   "Vireillepano"
                   "Siirry käsittelyyn")))))
 
-(defn- read-resource [resource]
-  (-> resource io/resource slurp str/trim))
-
 (defn- info-request [context]
-  (clostache.parser/render-resource "asha/logtoimenpide/info-request-template.xml" context))
+  (render-resource "asha/logtoimenpide/info-request-template.xml" context))
 
 (defn- info-response [context]
-  (clostache.parser/render-resource "asha/logtoimenpide/info-response-template.xml" context))
+  (render-resource "asha/logtoimenpide/info-response-template.xml" context))
 
 (defn- take-processing-action-request [context]
-  (clostache.parser/render-resource "asha/logtoimenpide/take-processing-action-request-template.xml" context))
+  (render-resource "asha/logtoimenpide/take-processing-action-request-template.xml" context))
 
 (defn- processing-action-ready-request [context]
-  (clostache.parser/render-resource "asha/logtoimenpide/ready-request-template.xml" context))
-
-(defn- read-template [resource context]
-  (clostache.parser/render-resource resource context))
+  (render-resource "asha/logtoimenpide/ready-request-template.xml" context))
 
 (t/deftest log-toimenpide!-test
   (t/testing "The case is new. The processing action operation is set to Vireillepano, instead of the default Käsittely. The case is not moved"
@@ -212,7 +206,7 @@
             {:response-status  200
              :request-received take-processing-action-called}
 
-            (read-template "asha/logtoimenpide/create-processing-action-operation-template.xml"
+            (render-resource "asha/logtoimenpide/create-processing-action-operation-template.xml"
                            (merge render-context {:processing-action                used-processing-action
                                                   :processing-action-operation-name processing-action-operation-name
                                                   :description                      description
@@ -245,7 +239,7 @@
     (let [sender-id "sender-id"
           request-id "request-id"
           case-number 100]
-      (t/testing "Move ignores the toimenpide if the action if toimenpide is"
+      (t/testing "Move ignores the toimenpide if the action is"
         (t/testing "Vireillepano"
           (asha-service/move-processing-action! sender-id request-id case-number {} "Vireillepano"))
         (t/testing "Tiedoksianto ja toimeenpano"
@@ -259,7 +253,7 @@
           (binding
             [asha-service/post!
              (handle-requests
-               {(read-template "asha/moveaction/move-template.xml" {:sender-id         sender-id
+               {(render-resource "asha/moveaction/move-template.xml" {:sender-id         sender-id
                                                                     :request-id        request-id
                                                                     :case-number       case-number
                                                                     :processing-action "Vireillepano"
@@ -271,7 +265,7 @@
             (t/is (= 1 @move-called)))))
       (t/testing "Move from Päätöksenteko to Käsittely"
         (let [move-called (atom 0)]
-          (binding [asha-service/post! (handle-requests {(read-template "asha/moveaction/move-template.xml" {:sender-id         sender-id
+          (binding [asha-service/post! (handle-requests {(render-resource "asha/moveaction/move-template.xml" {:sender-id         sender-id
                                                                                                              :request-id        request-id
                                                                                                              :case-number       case-number
                                                                                                              :processing-action "Käsittely"

--- a/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
@@ -3,8 +3,10 @@
             [clojure.string :as str]
             [clojure.test :as t]
             [solita.etp.service.asha :as asha-service]
-            [solita.etp.test-system :as ts])
+            [solita.etp.test-system :as ts]
+            [clostache.parser])
   (:import (java.nio.charset StandardCharsets)
+           (java.time Instant)
            (java.util Base64)))
 
 (t/use-fixtures :each ts/fixture)
@@ -17,18 +19,24 @@
       {:body   (-> response-resource io/resource slurp)
        :status response-status})))
 
-(t/deftest open-case-test
-  (binding [asha-service/post! (handle-request "asha/case-create-request.xml"
-                                               "asha/case-create-response.xml"
-                                               200)]
-    (t/is (= (asha-service/open-case!
-               {:sender-id      "test@example.com"
-                :request-id     "ETP-1"
-                :classification "05.03.02"
-                :service        "general"
-                :name           "Asunnot Oy"
-                :description    "Helsinki, Katu 1"})
-             "ARA-05.03.02-2021-31"))))
+(defn- handle-requests
+  "Take a map of request bodies, and corresponding responses. If a request is received that is not in the map, throw an exception."
+  [requests]
+  (fn [request]
+    (let [response (get requests request {:exception (Exception. (str "Unexpected request: " request))})
+          {response-body   :response-body
+           response-status :response-status
+           exception       :exception
+           request-atom    :request-received,
+           :or
+           {response-body nil
+            request-atom  (atom 0)}}
+          response]
+      (swap! request-atom inc)
+      (if exception
+        (throw (Exception. exception))
+        {:body   response-body
+         :status response-status}))))
 
 (t/deftest case-info-test
   (binding [asha-service/post! (handle-request "asha/case-info-request.xml"
@@ -43,34 +51,47 @@
               :description    "Helsinki, Katu 1"
               :created        "2021-03-22T10:28:13+02:00"}))))
 
+(t/deftest open-case-test
+  (binding [asha-service/post! (handle-request "asha/case-create-request.xml"
+                                               "asha/case-create-response.xml"
+                                               200)]
+    (t/is (= (asha-service/open-case!
+               {:sender-id      "test@example.com"
+                :request-id     "ETP-1"
+                :classification "05.03.02"
+                :service        "general"
+                :name           "Asunnot Oy"
+                :description    "Helsinki, Katu 1"})
+             "ARA-05.03.02-2021-31"))))
+
 (t/deftest action-info-test
   (binding [asha-service/post! (handle-request "asha/action-info-request.xml"
                                                "asha/action-info-response.xml"
                                                200)]
     (t/is (= (asha-service/action-info "test@example.com" "ETP-1" "ARA-05.03.02-2021-8" "Vireillepano")
              {:processing-action
-                        {:object-class         "ProcessingAction",
-                         :id                   578877,
-                         :version              8,
-                         :contacting-direction "NONE",
-                         :name                 "Vireillepano",
-                         :description          "Luodaan uusi asia.",
-                         :status               "READY",
-                         :created              "2021-03-25T12:47:08+02:00"},
+              {:object-class         "ProcessingAction",
+               :id                   578877,
+               :version              8,
+               :contacting-direction "NONE",
+               :name                 "Vireillepano",
+               :description          "Luodaan uusi asia.",
+               :status               "READY",
+               :created              "2021-03-25T12:47:08+02:00"},
               :assignee "FFAB23AE-E49F-4E3B-98D9-40C3DE0E4B46",
               :queue    24,
               :selected-decision
-                        {:decision "Siirry käsittelyyn",
-                         :next-processing-action
-                                   {:object-class         "ProcessingAction",
-                                    :id                   579176,
-                                    :version              1,
-                                    :contacting-direction "NONE",
-                                    :name                 "Käsittely",
-                                    :description
-                                                          "Asian käsittelyn toimenpiteitä, esim. lausunnon laatiminen, selvityksen tekeminen, päätöksen valmistelu",
-                                    :status               "NEW",
-                                    :created              "2021-03-25T14:01:07+02:00"}}}))))
+              {:decision "Siirry käsittelyyn",
+               :next-processing-action
+               {:object-class         "ProcessingAction",
+                :id                   579176,
+                :version              1,
+                :contacting-direction "NONE",
+                :name                 "Käsittely",
+                :description
+                "Asian käsittelyn toimenpiteitä, esim. lausunnon laatiminen, selvityksen tekeminen, päätöksen valmistelu",
+                :status               "NEW",
+                :created              "2021-03-25T14:01:07+02:00"}}}))))
 
 (t/deftest case-create-without-sender-id-test
   (binding [asha-service/post! (handle-request "asha/case-create-request-without-sender-id.xml"
@@ -135,3 +156,128 @@
                   "ARA-05.03.02-2021-8"
                   "Vireillepano"
                   "Siirry käsittelyyn")))))
+
+(defn- read-resource [resource]
+  (-> resource io/resource slurp str/trim))
+
+(defn- info-request [context]
+  (clostache.parser/render-resource "asha/logtoimenpide/info-request-template.xml" context))
+
+(defn- info-response [context]
+  (clostache.parser/render-resource "asha/logtoimenpide/info-response-template.xml" context))
+
+(defn- take-processing-action-request [context]
+  (clostache.parser/render-resource "asha/logtoimenpide/take-processing-action-request-template.xml" context))
+
+(defn- processing-action-ready-request [context]
+  (clostache.parser/render-resource "asha/logtoimenpide/ready-request-template.xml" context))
+
+(defn- read-template [resource context]
+  (clostache.parser/render-resource resource context))
+
+(t/deftest log-toimenpide!-test
+  (t/testing "The case is new. The processing action operation is set to Vireillepano, instead of the default Käsittely. The case is not moved"
+    (let [request-id "request-id"
+          case-number 100
+          sender-id "solita"
+          original-processing-action "Käsittely"
+          used-processing-action "Vireillepano"
+          processing-action-operation-name "Kehotus"
+          description "Kuvaus"
+          now (Instant/now)
+          take-processing-action-called (atom 0)
+          create-processing-action-operation (atom 0)
+          take-processing-action-for-operation (atom 0)
+          mark-processing-action-operation-ready (atom 0)
+          render-context {:request-id  request-id
+                          :case-number case-number
+                          :sender-id   sender-id}]
+      (binding
+        [asha-service/post!
+         (handle-requests
+           {(info-request (merge render-context {:processing-action "Vireillepano"}))
+            {:response-body   (info-response (merge render-context {:processing-action "Vireillepano" :processing-action-status "NEW"}))
+             :response-status 200}
+
+            (info-request (merge render-context {:processing-action "Käsittely"}))
+            {:exception (Exception. "No such processing action")} ;; NOTE: Not sure if this is actually how ASHA behaves, but the effect is the same - non-existing processing actions do not exist in the constructed status map
+
+            (info-request (merge render-context {:processing-action "Päätöksenteko"}))
+            {:exception (Exception. "No such processing action")}
+
+            (info-request (merge render-context {:processing-action "Tiedoksianto ja toimeenpano"}))
+            {:exception (Exception. "No such processing action")}
+
+            (take-processing-action-request (merge render-context {:processing-action used-processing-action}))
+            {:response-status  200
+             :request-received take-processing-action-called}
+
+            (read-template "asha/logtoimenpide/create-processing-action-operation-template.xml"
+                           (merge render-context {:processing-action                used-processing-action
+                                                  :processing-action-operation-name processing-action-operation-name
+                                                  :description                      description
+                                                  :reception-date                   now}))
+            {:response-status  200
+             :request-received create-processing-action-operation}
+
+            (take-processing-action-request (merge render-context {:processing-action processing-action-operation-name}))
+            {:response-status  200
+             :request-received take-processing-action-for-operation}
+
+            (processing-action-ready-request (merge render-context {:processing-action processing-action-operation-name}))
+            {:response-status  200
+             :request-received mark-processing-action-operation-ready}})]
+        (asha-service/log-toimenpide! sender-id
+                                      request-id
+                                      case-number
+                                      {:identity          {:case              {:number case-number}
+                                                           :processing-action {:name-identity original-processing-action}}
+                                       :processing-action {:name           processing-action-operation-name
+                                                           :reception-date now
+                                                           :description    description}}))
+      (t/is (= 1 @take-processing-action-called))
+      (t/is (= 1 @create-processing-action-operation))
+      (t/is (= 1 @take-processing-action-for-operation))
+      (t/is (= 1 @mark-processing-action-operation-ready)))))
+
+(t/deftest move-processing-action-test
+  (binding [asha-service/post! (handle-requests {})]        ;; There should be no requests - fail all
+    (let [sender-id "sender-id"
+          request-id "request-id"
+          case-number 100]
+      (t/testing "Move ignores the toimenpide if the action if toimenpide is"
+        (t/testing "Vireillepano"
+          (asha-service/move-processing-action! sender-id request-id case-number {} "Vireillepano"))
+        (t/testing "Tiedoksianto ja toimeenpano"
+          (asha-service/move-processing-action! sender-id request-id case-number {} "Tiedoksianto ja toimeenpano")))
+      (t/testing "Move is skipped if the toimenpide is already in correct state"
+        (let [processing-action-states {"Vireillepano" "READY" "Käsittely" "NEW"}
+              processing-action "Käsittely"]
+          (asha-service/move-processing-action! sender-id request-id case-number processing-action-states processing-action)))
+      (t/testing "Move from Vireillepano to Käsittely"
+        (let [move-called (atom 0)]
+          (binding
+            [asha-service/post!
+             (handle-requests
+               {(read-template "asha/moveaction/move-template.xml" {:sender-id         sender-id
+                                                                    :request-id        request-id
+                                                                    :case-number       case-number
+                                                                    :processing-action "Vireillepano"
+                                                                    :proceed-decision  "Siirry käsittelyyn"})
+                {:response-body    "Irrelevant"
+                 :response-status  200
+                 :request-received move-called}})]
+            (asha-service/move-processing-action! sender-id request-id case-number {} "Käsittely")
+            (t/is (= 1 @move-called)))))
+      (t/testing "Move from Päätöksenteko to Käsittely"
+        (let [move-called (atom 0)]
+          (binding [asha-service/post! (handle-requests {(read-template "asha/moveaction/move-template.xml" {:sender-id         sender-id
+                                                                                                             :request-id        request-id
+                                                                                                             :case-number       case-number
+                                                                                                             :processing-action "Käsittely"
+                                                                                                             :proceed-decision  "Siirry päätöksentekoon"})
+                                                         {:response-body    "Irrelevant"
+                                                          :response-status  200
+                                                          :request-received move-called}})]
+            (asha-service/move-processing-action! sender-id request-id case-number {} "Päätöksenteko")
+            (t/is (= 1 @move-called))))))))

--- a/etp-backend/src/test/resources/asha/logtoimenpide/create-processing-action-operation-template.xml
+++ b/etp-backend/src/test/resources/asha/logtoimenpide/create-processing-action-operation-template.xml
@@ -1,0 +1,30 @@
+<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap-env:Header>
+        <ns0:MessageHeader xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:messageVersion>1.0</ns0:messageVersion>
+            <ns0:requestId>{{request-id}}</ns0:requestId>
+            <ns0:senderId>{{sender-id}}</ns0:senderId>
+        </ns0:MessageHeader>
+    </soap-env:Header>
+    <soap-env:Body>
+        <ns0:executeOperations xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:operationRequest>
+                <ns0:IdentityChain>
+                    <ns0:CaseNumberIdentity>
+                        <ns0:caseNumber>{{case-number}}</ns0:caseNumber>
+                    </ns0:CaseNumberIdentity>
+                    <ns0:ProcessingActionNameIdentity>
+                        <ns0:name>{{processing-action}}</ns0:name>
+                    </ns0:ProcessingActionNameIdentity>
+                </ns0:IdentityChain>
+                <ns0:CreateProcessingActionOperation>
+                    <ns0:name>{{processing-action-operation-name}}</ns0:name>
+                    <!--TODO: required? <ns0:createFromProcess></ns0:createFromProcess>-->
+                    <ns0:receptionDate>{{reception-date}}</ns0:receptionDate>
+                    <ns0:contactingDirection></ns0:contactingDirection>
+                    <ns0:description>{{description}}</ns0:description>
+                </ns0:CreateProcessingActionOperation>
+            </ns0:operationRequest>
+        </ns0:executeOperations>
+    </soap-env:Body>
+</soap-env:Envelope>

--- a/etp-backend/src/test/resources/asha/logtoimenpide/info-request-template.xml
+++ b/etp-backend/src/test/resources/asha/logtoimenpide/info-request-template.xml
@@ -1,0 +1,25 @@
+<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap-env:Header>
+        <ns0:MessageHeader xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:messageVersion>1.0</ns0:messageVersion>
+            <ns0:requestId>{{request-id}}</ns0:requestId>
+            <ns0:senderId>{{sender-id}}</ns0:senderId>
+        </ns0:MessageHeader>
+    </soap-env:Header>
+    <soap-env:Body>
+        <ns0:executeOperations xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:operationRequest>
+                <ns0:ActionInfoQueryOperation>
+                    <ns0:IdentityChain>
+                        <ns0:CaseNumberIdentity>
+                            <ns0:caseNumber>{{case-number}}</ns0:caseNumber>
+                        </ns0:CaseNumberIdentity>
+                        <ns0:ProcessingActionNameIdentity>
+                            <ns0:name>{{processing-action}}</ns0:name>
+                        </ns0:ProcessingActionNameIdentity>
+                    </ns0:IdentityChain>
+                </ns0:ActionInfoQueryOperation>
+            </ns0:operationRequest>
+        </ns0:executeOperations>
+    </soap-env:Body>
+</soap-env:Envelope>

--- a/etp-backend/src/test/resources/asha/logtoimenpide/info-response-template.xml
+++ b/etp-backend/src/test/resources/asha/logtoimenpide/info-response-template.xml
@@ -1,0 +1,46 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <executeOperationsResponse xmlns="http://vismaconsulting.fi/ebs/1.0">
+            <return>
+                <ActionInfoResponse>
+                    <objectIdentity>
+                        <objectClass>ProcessingAction</objectClass>
+                        <id>578877</id>
+                        <version>8</version>
+                    </objectIdentity>
+                    <processingAction>
+                        <objectIdentity>
+                            <objectClass>ProcessingAction</objectClass>
+                            <id>578877</id>
+                            <version>8</version>
+                        </objectIdentity>
+                        <contactingDirection>NONE</contactingDirection>
+                        <name>{{processing-action}}</name>
+                        <description>Luodaan uusi asia.</description>
+                        <status>{{processing-action-status}}</status>
+                        <created>2021-03-25T12:47:08+02:00</created>
+                    </processingAction>
+                    <assignee>FFAB23AE-E49F-4E3B-98D9-40C3DE0E4B46</assignee>
+                    <queue>24</queue>
+                    <selectedDecision>
+                        <decision>Siirry käsittelyyn</decision>
+                        <nextProcessingAction>
+                            <objectIdentity>
+                                <objectClass>ProcessingAction</objectClass>
+                                <id>579176</id>
+                                <version>1</version>
+                            </objectIdentity>
+                            <contactingDirection>NONE</contactingDirection>
+                            <name>Käsittely</name>
+                            <description>Asian käsittelyn toimenpiteitä, esim. lausunnon laatiminen, selvityksen
+                                tekeminen, päätöksen valmistelu
+                            </description>
+                            <status>NEW</status>
+                            <created>2021-03-25T14:01:07+02:00</created>
+                        </nextProcessingAction>
+                    </selectedDecision>
+                </ActionInfoResponse>
+            </return>
+        </executeOperationsResponse>
+    </soap:Body>
+</soap:Envelope>

--- a/etp-backend/src/test/resources/asha/logtoimenpide/ready-request-template.xml
+++ b/etp-backend/src/test/resources/asha/logtoimenpide/ready-request-template.xml
@@ -1,0 +1,26 @@
+<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap-env:Header>
+        <ns0:MessageHeader xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:messageVersion>1.0</ns0:messageVersion>
+            <ns0:requestId>{{request-id}}</ns0:requestId>
+            <ns0:senderId>{{sender-id}}</ns0:senderId>
+        </ns0:MessageHeader>
+    </soap-env:Header>
+    <soap-env:Body>
+        <ns0:executeOperations xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:operationRequest>
+                <ns0:IdentityChain>
+                    <ns0:CaseNumberIdentity>
+                        <ns0:caseNumber>{{case-number}}</ns0:caseNumber>
+                    </ns0:CaseNumberIdentity>
+                    <ns0:ProcessingActionNameIdentity>
+                        <ns0:name>{{processing-action}}</ns0:name>
+                    </ns0:ProcessingActionNameIdentity>
+                </ns0:IdentityChain>
+                <ns0:ProceedOperation>
+                    <ns0:decision>Valmis</ns0:decision>
+                </ns0:ProceedOperation>
+            </ns0:operationRequest>
+        </ns0:executeOperations>
+    </soap-env:Body>
+</soap-env:Envelope>

--- a/etp-backend/src/test/resources/asha/logtoimenpide/take-processing-action-request-template.xml
+++ b/etp-backend/src/test/resources/asha/logtoimenpide/take-processing-action-request-template.xml
@@ -1,0 +1,26 @@
+<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap-env:Header>
+        <ns0:MessageHeader xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:messageVersion>1.0</ns0:messageVersion>
+            <ns0:requestId>{{request-id}}</ns0:requestId>
+            <ns0:senderId>{{sender-id}}</ns0:senderId>
+        </ns0:MessageHeader>
+    </soap-env:Header>
+    <soap-env:Body>
+        <ns0:executeOperations xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:operationRequest>
+                <ns0:IdentityChain>
+                    <ns0:CaseNumberIdentity>
+                        <ns0:caseNumber>{{case-number}}</ns0:caseNumber>
+                    </ns0:CaseNumberIdentity>
+                    <ns0:ProcessingActionNameIdentity>
+                        <ns0:name>{{processing-action}}</ns0:name>
+                    </ns0:ProcessingActionNameIdentity>
+                </ns0:IdentityChain>
+                <ns0:StartProcessingOperation>
+                    <ns0:assignee>{{sender-id}}</ns0:assignee>
+                </ns0:StartProcessingOperation>
+            </ns0:operationRequest>
+        </ns0:executeOperations>
+    </soap-env:Body>
+</soap-env:Envelope>

--- a/etp-backend/src/test/resources/asha/moveaction/move-template.xml
+++ b/etp-backend/src/test/resources/asha/moveaction/move-template.xml
@@ -1,0 +1,26 @@
+<soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap-env:Header>
+        <ns0:MessageHeader xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:messageVersion>1.0</ns0:messageVersion>
+            <ns0:requestId>{{request-id}}</ns0:requestId>
+            <ns0:senderId>{{sender-id}}</ns0:senderId>
+        </ns0:MessageHeader>
+    </soap-env:Header>
+    <soap-env:Body>
+        <ns0:executeOperations xmlns:ns0="http://vismaconsulting.fi/ebs/1.0">
+            <ns0:operationRequest>
+                <ns0:IdentityChain>
+                    <ns0:CaseNumberIdentity>
+                        <ns0:caseNumber>{{case-number}}</ns0:caseNumber>
+                    </ns0:CaseNumberIdentity>
+                    <ns0:ProcessingActionNameIdentity>
+                        <ns0:name>{{processing-action}}</ns0:name>
+                    </ns0:ProcessingActionNameIdentity>
+                </ns0:IdentityChain>
+                <ns0:ProceedOperation>
+                    <ns0:decision>{{proceed-decision}}</ns0:decision>
+                </ns0:ProceedOperation>
+            </ns0:operationRequest>
+        </ns0:executeOperations>
+    </soap-env:Body>
+</soap-env:Envelope>


### PR DESCRIPTION
### Move Kehotus to Vireillepano in Asha

Earlier there was a separate Tietopyyntö step in the Valvonta, and
Kehotus was in Käsittely. Now the Tietopyyntö does not exists, and the
Kehotus should be in Vireillepano. The first Kehotus in a case went
correctly to Vireillepano because of the asha logic to require it as the
first step in the process, but following ones did not.

Fixed by moving Kehotus to Vireillepano to match the new process.