### PR TITLE
Bring in a newer Jetty client

### DIFF
--- a/etp-backend/deps.edn
+++ b/etp-backend/deps.edn
@@ -45,7 +45,8 @@
                                                                       ring/ring-jetty-adapter
                                                                       org.clojure/data.json]}
              org.clojure/core.match                    {:mvn/version "1.0.1"}
-             com.cognitect.aws/api                     {:mvn/version "0.8.686"}
+             com.cognitect.aws/api                     {:mvn/version "0.8.686"
+                                                        :exclusions  [org.eclipse.jetty/jetty-client]} ; Replaced by a newer version
              org.eclipse.jetty/jetty-client            {:mvn/version "9.4.52.v20230823"} ; aws-api uses vulnerable jetty version. Bring in a bit newer one
              com.cognitect.aws/endpoints               {:mvn/version "1.1.12.504"}
              com.cognitect.aws/s3                      {:mvn/version "848.2.1413.0"}

--- a/etp-backend/deps.edn
+++ b/etp-backend/deps.edn
@@ -46,6 +46,7 @@
                                                                       org.clojure/data.json]}
              org.clojure/core.match                    {:mvn/version "1.0.1"}
              com.cognitect.aws/api                     {:mvn/version "0.8.686"}
+             org.eclipse.jetty/jetty-client            {:mvn/version "9.4.52.v20230823"} ; aws-api uses vulnerable jetty version. Bring in a bit newer one
              com.cognitect.aws/endpoints               {:mvn/version "1.1.12.504"}
              com.cognitect.aws/s3                      {:mvn/version "848.2.1413.0"}
              de.ubercode.clostache/clostache           {:mvn/version "1.4.0"}


### PR DESCRIPTION
Aws api uses an outdated Jetty version. Bring in a bit newer version to get rid of vulnerabilities.