### PR TITLE
AE-1976 Add the missing muu käytettävä energiamuoto entries

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/service/energiatodistus_csv.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/energiatodistus_csv.clj
@@ -101,9 +101,10 @@
                 :kaukojaahdytys-nettoala-kertoimella
                 :valaistus-kuluttaja-sahko :valaistus-kuluttaja-sahko-nettoala]]
      [:tulokset :kaytettavat-energiamuodot child])
-   (for [child [:nimi :ostoenergia :muotokerroin :ostoenergia-nettoala
+   (for [idx (range 3)
+         child [:nimi :ostoenergia :muotokerroin :ostoenergia-nettoala
                 :ostoenergia-kertoimella :ostoenergia-nettoala-kertoimella]]
-     [:tulokset :kaytettavat-energiamuodot :muu 0 child])
+     [:tulokset :kaytettavat-energiamuodot :muu idx child])
    [[:tulokset :kaytettavat-energiamuodot :summa]
     [:tulokset :kaytettavat-energiamuodot :kertoimella-summa]]
    (for [child [:aurinkosahko :aurinkosahko-nettoala :aurinkolampo
@@ -490,9 +491,10 @@
                 :kaukojaahdytys-kertoimella
                 :kaukojaahdytys-nettoala-kertoimella]]
      [:tulokset :kaytettavat-energiamuodot child])
-   (for [child [:nimi :ostoenergia :muotokerroin :ostoenergia-nettoala
+   (for [idx (range 3)
+         child [:nimi :ostoenergia :muotokerroin :ostoenergia-nettoala
                 :ostoenergia-kertoimella :ostoenergia-nettoala-kertoimella]]
-     [:tulokset :kaytettavat-energiamuodot :muu 0 child])
+     [:tulokset :kaytettavat-energiamuodot :muu idx child])
    [[:tulokset :kaytettavat-energiamuodot :summa]
     [:tulokset :kaytettavat-energiamuodot :kertoimella-summa]]
    (for [child [:aurinkosahko :aurinkosahko-nettoala :aurinkolampo


### PR DESCRIPTION
It was checked that the production data set has three muu energiamuoto entries at maximum. In theory there could be more, but even three is a relatively rare number. We are not really expecting more 2013 energiatodistus to get added.