### PR TITLE
AE-1987: Käskypäätös / varsinainen päätös changes

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
@@ -48,16 +48,33 @@
 
 (def KarajaoikeusId (apply schema/enum (range 0 20)))
 
-(def KaskyPaatosVarsinainenPaatosData {:fine                     common-schema/NonNegative
-                                       :osapuoli-specific-data   [{:osapuoli-id          common-schema/Key
-                                                                   :hallinto-oikeus-id   (schema/maybe HallintoOikeusId)
-                                                                   :document             schema/Bool
-                                                                   ;; Conditional-skeema documentin perusteella, jos false niin seuraavia ei vaadita / saa olla?
-                                                                   :recipient-answered   schema/Bool
-                                                                   :answer-commentary-fi (schema/maybe schema/Str)
-                                                                   :answer-commentary-sv (schema/maybe schema/Str)
-                                                                   :statement-fi         (schema/maybe schema/Str)
-                                                                   :statement-sv         (schema/maybe schema/Str)}]
+(def KaskypaatosVarsinainenPaatosOsapuoliSpecificData
+  (schema/conditional
+    ;; Osapuoli has a document and has answered to kuulemiskirje, so all fields are required
+    (every-pred toimenpide/osapuoli-has-document? toimenpide/recipient-answered?)
+    {:osapuoli-id          common-schema/Key
+     :hallinto-oikeus-id   HallintoOikeusId
+     :document             schema/Bool
+     :recipient-answered   schema/Bool
+     :answer-commentary-fi schema/Str
+     :answer-commentary-sv schema/Str
+     :statement-fi         schema/Str
+     :statement-sv         schema/Str}
+
+    ;; Osapuoli has document but has not answered to kuulemiskirje, so answer and statement are not allowed
+    toimenpide/osapuoli-has-document?
+    {:osapuoli-id        common-schema/Key
+     :hallinto-oikeus-id HallintoOikeusId
+     :document           schema/Bool
+     :recipient-answered schema/Bool}
+
+    ;; Osapuoli has no document so no other fields are allowed
+    :else
+    {:osapuoli-id common-schema/Key
+     :document    schema/Bool}))
+
+(def KaskypaatosVarsinainenPaatosData {:fine                     common-schema/NonNegative
+                                       :osapuoli-specific-data   [KaskypaatosVarsinainenPaatosOsapuoliSpecificData]
                                        :department-head-title-fi schema/Str
                                        :department-head-title-sv schema/Str
                                        :department-head-name     schema/Str})
@@ -75,7 +92,7 @@
     (assoc ToimenpideAddBase :type-specific-data KaskypaatosKuulemiskirjeData)
 
     toimenpide/kaskypaatos-varsinainen-paatos?
-    (assoc ToimenpideAddBase :type-specific-data KaskyPaatosVarsinainenPaatosData)
+    (assoc ToimenpideAddBase :type-specific-data KaskypaatosVarsinainenPaatosData)
 
     toimenpide/kaskypaatos-haastemies-tiedoksianto?
     (assoc ToimenpideAddBase :type-specific-data KaskypaatosTiedoksiantoHaastemiesData)
@@ -129,7 +146,7 @@
                   (assoc ToimenpideBase :type-specific-data KaskypaatosKuulemiskirjeData)
 
                   toimenpide/kaskypaatos-varsinainen-paatos?
-                  (assoc ToimenpideBase :type-specific-data KaskyPaatosVarsinainenPaatosData)
+                  (assoc ToimenpideBase :type-specific-data KaskypaatosVarsinainenPaatosData)
 
                   toimenpide/kaskypaatos-haastemies-tiedoksianto?
                   (assoc ToimenpideBase :type-specific-data KaskypaatosTiedoksiantoHaastemiesData)

--- a/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
@@ -49,14 +49,15 @@
 (def KarajaoikeusId (apply schema/enum (range 0 20)))
 
 (def KaskyPaatosVarsinainenPaatosData {:fine                     common-schema/NonNegative
-                                       :recipient-answered       schema/Bool
-                                       :answer-commentary-fi     schema/Str
-                                       :answer-commentary-sv     schema/Str
-                                       :statement-fi             schema/Str
-                                       :statement-sv             schema/Str
-                                       :osapuoli-specific-data   [{:osapuoli-id        common-schema/Key
-                                                                   :hallinto-oikeus-id (schema/maybe HallintoOikeusId)
-                                                                   :document           schema/Bool}]
+                                       :osapuoli-specific-data   [{:osapuoli-id          common-schema/Key
+                                                                   :hallinto-oikeus-id   (schema/maybe HallintoOikeusId)
+                                                                   :document             schema/Bool
+                                                                   ;; Conditional-skeema documentin perusteella, jos false niin seuraavia ei vaadita / saa olla?
+                                                                   :recipient-answered   schema/Bool
+                                                                   :answer-commentary-fi (schema/maybe schema/Str)
+                                                                   :answer-commentary-sv (schema/maybe schema/Str)
+                                                                   :statement-fi         (schema/maybe schema/Str)
+                                                                   :statement-sv         (schema/maybe schema/Str)}]
                                        :department-head-title-fi schema/Str
                                        :department-head-title-sv schema/Str
                                        :department-head-name     schema/Str})

--- a/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
+++ b/etp-backend/src/main/clj/solita/etp/schema/valvonta_kaytto.clj
@@ -79,10 +79,20 @@
                                        :department-head-title-sv schema/Str
                                        :department-head-name     schema/Str})
 
-(def KaskypaatosTiedoksiantoHaastemiesData {:osapuoli-specific-data [{:osapuoli-id      common-schema/Key
-                                                                      :karajaoikeus-id  (schema/maybe KarajaoikeusId)
-                                                                      :haastemies-email (schema/maybe common-schema/Email)
-                                                                      :document         schema/Bool}]})
+(def KaskypaatosTiedoksiantoHaastemiesOsapuoliSpecificData
+  (schema/conditional
+    toimenpide/osapuoli-has-document?
+    {:osapuoli-id      common-schema/Key
+     :karajaoikeus-id  KarajaoikeusId
+     :haastemies-email common-schema/Email
+     :document         schema/Bool}
+
+    :else
+    {:osapuoli-id common-schema/Key
+     :document    schema/Bool}))
+
+(def KaskypaatosTiedoksiantoHaastemiesData
+  {:osapuoli-specific-data [KaskypaatosTiedoksiantoHaastemiesOsapuoliSpecificData]})
 
 (def SakkoPaatosKuulemiskirjeData {:fine common-schema/NonNegative})
 

--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/asha.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/asha.clj
@@ -316,7 +316,7 @@
                                                            (find-administrative-court-id-from-osapuoli-specific-data (:id osapuoli))))
       generated-pdf)))
 
-(defn filter-osapuolet-with-no-document
+(defn remove-osapuolet-with-no-document
   "If toimenpidetype of the toimenpide is such that the document might not be created for some,
   osapuolet will be filtered so that only those are returned that have a :document as true
   specified in type-specific-data of the toimenpide.
@@ -326,7 +326,6 @@
     (let [osapuolet-with-document (->> toimenpide
                                        :type-specific-data
                                        :osapuoli-specific-data
-
                                        (filter toimenpide/osapuoli-has-document?)
                                        (map :osapuoli-id)
                                        set)]
@@ -341,7 +340,7 @@
         documents (when (:document processing-action)
                     (->> osapuolet
                          (filter osapuoli/omistaja?)
-                         (filter-osapuolet-with-no-document toimenpide)
+                         (remove-osapuolet-with-no-document toimenpide)
                          (map (fn [osapuoli]
                                 (let [document (generate-pdf-document db whoami valvonta toimenpide ilmoituspaikat
                                                                       osapuoli osapuolet roolit)]

--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/asha.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/asha.clj
@@ -326,7 +326,8 @@
     (let [osapuolet-with-document (->> toimenpide
                                        :type-specific-data
                                        :osapuoli-specific-data
-                                       (filter #(true? (:document %)))
+
+                                       (filter toimenpide/osapuoli-has-document?)
                                        (map :osapuoli-id)
                                        set)]
       (filter #(contains? osapuolet-with-document (:id %)) osapuolet))

--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/asha.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/asha.clj
@@ -84,38 +84,59 @@
     (exception/throw-ex-info!
       {:message (str "Unknown hallinto-oikeus-id: " hallinto-oikeus-id)})))
 
-(defn find-administrative-court-id-from-osapuoli-specific-data [osapuoli-specific-data osapuoli-id]
+(defn- find-value-from-osapuoli-specific-data [key osapuoli-specific-data osapuoli-id]
   (->> osapuoli-specific-data
        (filter #(= (:osapuoli-id %) osapuoli-id))
        first
-       :hallinto-oikeus-id))
+       key))
+
+(def find-administrative-court-id-from-osapuoli-specific-data
+  (partial find-value-from-osapuoli-specific-data :hallinto-oikeus-id))
+
+(def find-recipient-answered-from-osapuoli-specific-data
+  (partial find-value-from-osapuoli-specific-data :recipient-answered))
 
 (defmulti format-type-specific-data
           (fn [_db toimenpide _osapuoli-id] (-> toimenpide :type-id toimenpide/type-key)))
 
 (defmethod format-type-specific-data :decision-order-actual-decision [db toimenpide osapuoli-id]
-  (let [recipient-answered? (-> toimenpide :type-specific-data :recipient-answered)
+  (let [recipient-answered? (-> toimenpide
+                                :type-specific-data
+                                :osapuoli-specific-data
+                                (find-recipient-answered-from-osapuoli-specific-data osapuoli-id))
         hallinto-oikeus-strings (hallinto-oikeus-id->formatted-strings
                                   db
                                   (-> toimenpide
                                       :type-specific-data
                                       :osapuoli-specific-data
                                       (find-administrative-court-id-from-osapuoli-specific-data osapuoli-id)))]
-    {:vastaus-fi               (str (if recipient-answered?
-                                      "Asianosainen antoi vastineen kuulemiskirjeeseen."
-                                      "Asianosainen ei vastannut kuulemiskirjeeseen.")
-                                    " "
-                                    (-> toimenpide :type-specific-data :answer-commentary-fi))
-     :vastaus-sv               (str (if recipient-answered?
-                                      "gav ett bemötande till brevet om hörande."
-                                      "svarade inte på brevet om hörande.")
-                                    " "
-                                    (-> toimenpide :type-specific-data :answer-commentary-sv))
+    {:recipient-answered       recipient-answered?
+     :vastaus-fi               (if recipient-answered?
+                                 (str "Asianosainen antoi vastineen kuulemiskirjeeseen. "
+                                      (-> toimenpide
+                                          :type-specific-data
+                                          :osapuoli-specific-data
+                                          ((partial find-value-from-osapuoli-specific-data :answer-commentary-fi) osapuoli-id)))
+                                 "Asianosainen ei vastannut kuulemiskirjeeseen.")
+
+     :vastaus-sv               (if recipient-answered?
+                                 (str "gav ett bemötande till brevet om hörande. "
+                                      (-> toimenpide
+                                          :type-specific-data
+                                          :osapuoli-specific-data
+                                          ((partial find-value-from-osapuoli-specific-data :answer-commentary-sv) osapuoli-id)))
+                                 "svarade inte på brevet om hörande.")
      :oikeus-fi                (:fi hallinto-oikeus-strings)
      :oikeus-sv                (:sv hallinto-oikeus-strings)
      :fine                     (-> toimenpide :type-specific-data :fine)
-     :statement-fi             (-> toimenpide :type-specific-data :statement-fi)
-     :statement-sv             (-> toimenpide :type-specific-data :statement-sv)
+     :statement-fi             (-> toimenpide
+                                   :type-specific-data
+                                   :osapuoli-specific-data
+                                   ((partial find-value-from-osapuoli-specific-data :statement-fi) osapuoli-id))
+     :statement-sv             (-> toimenpide
+                                   :type-specific-data
+                                   :osapuoli-specific-data
+                                   ((partial find-value-from-osapuoli-specific-data :statement-sv) osapuoli-id))
      :department-head-name     (-> toimenpide :type-specific-data :department-head-name)
      :department-head-title-fi (-> toimenpide :type-specific-data :department-head-title-fi)
      :department-head-title-sv (-> toimenpide :type-specific-data :department-head-title-sv)}))

--- a/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/toimenpide.clj
+++ b/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/toimenpide.clj
@@ -83,3 +83,10 @@
              (map :id)
              set)]
     (contains? manually-deliverable-toimenpidetypes type-id)))
+
+
+(defn osapuoli-has-document? [osapuoli-specific-data]
+  (boolean (:document osapuoli-specific-data)))
+
+(defn recipient-answered? [osapuoli-specific-data]
+  (boolean (:recipient-answered osapuoli-specific-data)))

--- a/etp-backend/src/test/clj/solita/etp/service/valvonta_kaytto/asha_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/valvonta_kaytto/asha_test.clj
@@ -213,14 +213,14 @@
                ts/*db*
                {:type-id            8
                 :type-specific-data {:fine                     129
-                                     :recipient-answered       true
-                                     :answer-commentary-fi     "Voi anteeksi, en tiennyt."
-                                     :answer-commentary-sv     "Jag vet inte, förlåt."
-                                     :statement-fi             "Olisi pitänyt tietää."
-                                     :statement-sv             "Du måste ha visst."
                                      :osapuoli-specific-data   [{:osapuoli-id        1
                                                                  :hallinto-oikeus-id 0
-                                                                 :document           true}]
+                                                                 :document           true
+                                                                 :recipient-answered       true
+                                                                 :answer-commentary-fi     "Voi anteeksi, en tiennyt."
+                                                                 :answer-commentary-sv     "Jag vet inte, förlåt."
+                                                                 :statement-fi             "Olisi pitänyt tietää."
+                                                                 :statement-sv             "Du måste ha visst."}]
                                      :department-head-name     "Jorma Jormanen"
                                      :department-head-title-fi "Hallinto-oikeuden presidentti"
                                      :department-head-title-sv "Hallinto-oikeuden kuningas"}}
@@ -234,7 +234,8 @@
               :oikeus-sv                "Helsingfors"
               :department-head-name     "Jorma Jormanen"
               :department-head-title-fi "Hallinto-oikeuden presidentti"
-              :department-head-title-sv "Hallinto-oikeuden kuningas"}))
+              :department-head-title-sv "Hallinto-oikeuden kuningas"
+              :recipient-answered true}))
 
     (t/testing "For käskypäätös / kuulemiskirje toimenpide :type-spefic-data map is returned as is, as no special formatting is needed"
       (t/is (= (asha/format-type-specific-data

--- a/etp-backend/src/test/clj/solita/etp/service/valvonta_kaytto/asha_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/service/valvonta_kaytto/asha_test.clj
@@ -302,7 +302,7 @@
                3)
              5))))
 
-(t/deftest filter-osapuolet-if-varsinainen-paatos-test
+(t/deftest remove-osapuolet-with-no-document-if-varsinainen-paatos-test
   (t/testing "Two osapuolis, one hallinto-oikeus, only the osapuoli with the hallinto-oikeus should be returned"
     (let [osapuolet [{:toimitustapa-description nil
                       :toimitustapa-id          0
@@ -361,7 +361,7 @@
                        :answer-commentary-sv     "Jag visste inte att ett intyg behövs :("
                        :answer-commentary-fi     "En tiennyt, että todistus tarvitaan :("}
                       :template-id  6}]
-      (t/is (= (asha/filter-osapuolet-with-no-document toimenpide osapuolet)
+      (t/is (= (asha/remove-osapuolet-with-no-document toimenpide osapuolet)
                [{:toimitustapa-description nil
                  :toimitustapa-id          0
                  :email                    nil
@@ -380,7 +380,7 @@
                  :maa                      "FI"}]))))
 
   (t/testing "Two osapuolis and two hallinto-oikeus selections, both osapuolet are returned"
-    (t/is (= (asha/filter-osapuolet-with-no-document
+    (t/is (= (asha/remove-osapuolet-with-no-document
                {:type-id            8
                 :type-specific-data {:osapuoli-specific-data [{:hallinto-oikeus-id 1
                                                                :osapuoli-id        2
@@ -394,7 +394,7 @@
               {:id 3}])))
 
   (t/testing "Two osapuolis and toimenpide is not varsinainen päätös, so both should be returned"
-    (t/is (= (asha/filter-osapuolet-with-no-document
+    (t/is (= (asha/remove-osapuolet-with-no-document
                {:type-id 7}
                [{:id 2}
                 {:id 3}])

--- a/etp-backend/src/test/clj/solita/etp/valvonta_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/valvonta_test.clj
@@ -766,7 +766,9 @@
                               :type-specific-data {:osapuoli-specific-data [{:osapuoli-id      1
                                                                              :karajaoikeus-id  1
                                                                              :haastemies-email "haaste@mie.het"
-                                                                             :document         true}]}}
+                                                                             :document         true}
+                                                                            {:osapuoli-id 2
+                                                                             :document    false}]}}
               response (ts/handler (-> (mock/request :post (format "/api/private/valvonta/kaytto/%s/toimenpiteet" valvonta-id))
                                        (mock/json-body new-toimenpide)
                                        (test-kayttajat/with-virtu-user)
@@ -813,7 +815,9 @@
                     :type-specific-data {:osapuoli-specific-data [{:document         true
                                                                    :haastemies-email "haaste@mie.het"
                                                                    :karajaoikeus-id  1
-                                                                   :osapuoli-id      1}]}
+                                                                   :osapuoli-id      1}
+                                                                  {:document    false
+                                                                   :osapuoli-id 2}]}
                     :valvonta-id        valvonta-id
                     :yritykset          []}))))))
 

--- a/etp-backend/src/test/clj/solita/etp/valvonta_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/valvonta_test.clj
@@ -470,14 +470,10 @@
                               :template-id        6
                               :description        "Tehdään varsinainen päätös, omistaja vastasi kuulemiskirjeeseen"
                               :type-specific-data {:fine                     857
-                                                   :osapuoli-specific-data   [{:osapuoli-id          osapuoli-id
-                                                                               :hallinto-oikeus-id   2
-                                                                               :document             true
-                                                                               :recipient-answered   false
-                                                                               :answer-commentary-fi nil
-                                                                               :answer-commentary-sv nil
-                                                                               :statement-fi         nil
-                                                                               :statement-sv         nil}]
+                                                   :osapuoli-specific-data   [{:osapuoli-id        osapuoli-id
+                                                                               :hallinto-oikeus-id 2
+                                                                               :document           true
+                                                                               :recipient-answered false}]
                                                    :department-head-title-fi "Senior Vice President"
                                                    :department-head-title-sv "Kungen"
                                                    :department-head-name     "Jane Doe"}}
@@ -528,14 +524,10 @@
                                 {:department-head-title-fi "Senior Vice President",
                                  :department-head-name     "Jane Doe",
                                  :osapuoli-specific-data
-                                 [{:hallinto-oikeus-id   2
-                                   :osapuoli-id          1
-                                   :document             true
-                                   :recipient-answered   false
-                                   :statement-sv         nil
-                                   :statement-fi         nil
-                                   :answer-commentary-sv nil
-                                   :answer-commentary-fi nil}]
+                                 [{:hallinto-oikeus-id 2
+                                   :osapuoli-id        1
+                                   :document           true
+                                   :recipient-answered false}]
                                  :department-head-title-sv "Kungen"
                                  :fine                     857,},
                                 :template-id   6}))))))))
@@ -634,15 +626,8 @@
                                                                                :answer-commentary-sv "Jag visste inte att ett intyg behövs :("
                                                                                :statement-fi         "Tämän kerran annetaan anteeksi, kun hän ei tiennyt."
                                                                                :statement-sv         "Han vet inte. Vi förlotar."}
-                                                                              ;; TODO: Muuta skeema niin, että tässä ei tarvita turhia kenttiä
-                                                                              {:osapuoli-id          osapuoli-id-2
-                                                                               :hallinto-oikeus-id   nil
-                                                                               :document             false
-                                                                               :recipient-answered   false
-                                                                               :answer-commentary-fi nil
-                                                                               :answer-commentary-sv nil
-                                                                               :statement-fi         nil
-                                                                               :statement-sv         nil}]
+                                                                              {:osapuoli-id osapuoli-id-2
+                                                                               :document    false}]
                                                    :department-head-title-fi "Apulaisjohtaja"
                                                    :department-head-title-sv "Apulaisjohtaja på svenska"
                                                    :department-head-name     "Yli Päällikkö"}}
@@ -681,14 +666,10 @@
                             :template-id        6
                             :description        "Tehdään varsinainen päätös, omistaja vastasi kuulemiskirjeeseen"
                             :type-specific-data {:fine                     857
-                                                 :osapuoli-specific-data   [{:osapuoli-id          osapuoli-id
-                                                                             :hallinto-oikeus-id   3
-                                                                             :document             true
-                                                                             :recipient-answered   false
-                                                                             :answer-commentary-fi nil
-                                                                             :answer-commentary-sv nil
-                                                                             :statement-fi         nil
-                                                                             :statement-sv         nil}]
+                                                 :osapuoli-specific-data   [{:osapuoli-id        osapuoli-id
+                                                                             :hallinto-oikeus-id 3
+                                                                             :document           true
+                                                                             :recipient-answered false}]
                                                  :department-head-title-fi "Johtaja"
                                                  :department-head-title-sv "Ledar"
                                                  :department-head-name     "Nimi Muutettu"}}

--- a/etp-backend/src/test/clj/solita/etp/valvonta_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/valvonta_test.clj
@@ -386,14 +386,14 @@
                               :template-id        6
                               :description        "Tehdään varsinainen päätös, omistaja vastasi kuulemiskirjeeseen"
                               :type-specific-data {:fine                     857
-                                                   :recipient-answered       true
-                                                   :answer-commentary-fi     "En tiennyt, että todistus tarvitaan :("
-                                                   :answer-commentary-sv     "Jag visste inte att ett intyg behövs :("
-                                                   :statement-fi             "Tämän kerran annetaan anteeksi, kun hän ei tiennyt."
-                                                   :statement-sv             "Han vet inte. Vi förlotar."
-                                                   :osapuoli-specific-data   [{:osapuoli-id        osapuoli-id
-                                                                               :hallinto-oikeus-id 1
-                                                                               :document           true}]
+                                                   :osapuoli-specific-data   [{:osapuoli-id          osapuoli-id
+                                                                               :hallinto-oikeus-id   1
+                                                                               :document             true
+                                                                               :recipient-answered   true
+                                                                               :answer-commentary-fi "En tiennyt, että todistus tarvitaan :("
+                                                                               :answer-commentary-sv "Jag visste inte att ett intyg behövs :("
+                                                                               :statement-fi         "Tämän kerran annetaan anteeksi, kun hän ei tiennyt."
+                                                                               :statement-sv         "Han vet inte. Vi förlotar."}]
                                                    :department-head-title-fi "Apulaisjohtaja"
                                                    :department-head-title-sv "Apulaisjohtaja på svenska"
                                                    :department-head-name     "Yli Päällikkö"}}
@@ -470,14 +470,14 @@
                               :template-id        6
                               :description        "Tehdään varsinainen päätös, omistaja vastasi kuulemiskirjeeseen"
                               :type-specific-data {:fine                     857
-                                                   :recipient-answered       false
-                                                   :answer-commentary-fi     "Yritys ei ollut tavoitettavissa ollenkaan asian tiimoilta."
-                                                   :answer-commentary-sv     "Företaget var inte nåbar alls angående ärendet."
-                                                   :statement-fi             "Yritys tuomitaan sakkoihin."
-                                                   :statement-sv             "Företaget döms till böter."
-                                                   :osapuoli-specific-data   [{:osapuoli-id        osapuoli-id
-                                                                               :hallinto-oikeus-id 2
-                                                                               :document           true}]
+                                                   :osapuoli-specific-data   [{:osapuoli-id          osapuoli-id
+                                                                               :hallinto-oikeus-id   2
+                                                                               :document             true
+                                                                               :recipient-answered   false
+                                                                               :answer-commentary-fi nil
+                                                                               :answer-commentary-sv nil
+                                                                               :statement-fi         nil
+                                                                               :statement-sv         nil}]
                                                    :department-head-title-fi "Senior Vice President"
                                                    :department-head-title-sv "Kungen"
                                                    :department-head-name     "Jane Doe"}}
@@ -528,16 +528,16 @@
                                 {:department-head-title-fi "Senior Vice President",
                                  :department-head-name     "Jane Doe",
                                  :osapuoli-specific-data
-                                 [{:hallinto-oikeus-id 2, :osapuoli-id 1, :document true}],
-                                 :recipient-answered       false,
-                                 :statement-sv             "Företaget döms till böter.",
-                                 :statement-fi             "Yritys tuomitaan sakkoihin.",
-                                 :department-head-title-sv "Kungen",
-                                 :fine                     857,
-                                 :answer-commentary-sv
-                                 "Företaget var inte nåbar alls angående ärendet.",
-                                 :answer-commentary-fi
-                                 "Yritys ei ollut tavoitettavissa ollenkaan asian tiimoilta."},
+                                 [{:hallinto-oikeus-id   2
+                                   :osapuoli-id          1
+                                   :document             true
+                                   :recipient-answered   false
+                                   :statement-sv         nil
+                                   :statement-fi         nil
+                                   :answer-commentary-sv nil
+                                   :answer-commentary-fi nil}]
+                                 :department-head-title-sv "Kungen"
+                                 :fine                     857,},
                                 :template-id   6}))))))))
 
   (t/testing "Käskypäätös / varsinainen päätös toimenpide is created successfully when there are multiple osapuolis but one lives abroad and will not receive the document because of being outside court jurisdiction"
@@ -626,17 +626,23 @@
                               :template-id        6
                               :description        "Tehdään varsinainen päätös, omistaja vastasi kuulemiskirjeeseen"
                               :type-specific-data {:fine                     857
-                                                   :recipient-answered       true
-                                                   :answer-commentary-fi     "En tiennyt, että todistus tarvitaan :("
-                                                   :answer-commentary-sv     "Jag visste inte att ett intyg behövs :("
-                                                   :statement-fi             "Tämän kerran annetaan anteeksi, kun hän ei tiennyt."
-                                                   :statement-sv             "Han vet inte. Vi förlotar."
-                                                   :osapuoli-specific-data   [{:osapuoli-id        osapuoli-id
-                                                                               :hallinto-oikeus-id 1
-                                                                               :document           true}
-                                                                              {:osapuoli-id        osapuoli-id-2
-                                                                               :hallinto-oikeus-id nil
-                                                                               :document           false}]
+                                                   :osapuoli-specific-data   [{:osapuoli-id          osapuoli-id
+                                                                               :hallinto-oikeus-id   1
+                                                                               :document             true
+                                                                               :recipient-answered   true
+                                                                               :answer-commentary-fi "En tiennyt, että todistus tarvitaan :("
+                                                                               :answer-commentary-sv "Jag visste inte att ett intyg behövs :("
+                                                                               :statement-fi         "Tämän kerran annetaan anteeksi, kun hän ei tiennyt."
+                                                                               :statement-sv         "Han vet inte. Vi förlotar."}
+                                                                              ;; TODO: Muuta skeema niin, että tässä ei tarvita turhia kenttiä
+                                                                              {:osapuoli-id          osapuoli-id-2
+                                                                               :hallinto-oikeus-id   nil
+                                                                               :document             false
+                                                                               :recipient-answered   false
+                                                                               :answer-commentary-fi nil
+                                                                               :answer-commentary-sv nil
+                                                                               :statement-fi         nil
+                                                                               :statement-sv         nil}]
                                                    :department-head-title-fi "Apulaisjohtaja"
                                                    :department-head-title-sv "Apulaisjohtaja på svenska"
                                                    :department-head-name     "Yli Päällikkö"}}
@@ -675,14 +681,14 @@
                             :template-id        6
                             :description        "Tehdään varsinainen päätös, omistaja vastasi kuulemiskirjeeseen"
                             :type-specific-data {:fine                     857
-                                                 :recipient-answered       false
-                                                 :answer-commentary-fi     "Hän ei vastannut ollenkaan"
-                                                 :answer-commentary-sv     "Han svarade inte alls"
-                                                 :statement-fi             "Koska hän ei vastannut ollenkaan hän joutuu maksamaan paljon sakkoja."
-                                                 :statement-sv             "Eftersom han inte svarade alls måste han betala mycket böter."
-                                                 :osapuoli-specific-data   [{:osapuoli-id        osapuoli-id
-                                                                             :hallinto-oikeus-id 3
-                                                                             :document           true}]
+                                                 :osapuoli-specific-data   [{:osapuoli-id          osapuoli-id
+                                                                             :hallinto-oikeus-id   3
+                                                                             :document             true
+                                                                             :recipient-answered   false
+                                                                             :answer-commentary-fi nil
+                                                                             :answer-commentary-sv nil
+                                                                             :statement-fi         nil
+                                                                             :statement-sv         nil}]
                                                  :department-head-title-fi "Johtaja"
                                                  :department-head-title-sv "Ledar"
                                                  :department-head-name     "Nimi Muutettu"}}
@@ -716,14 +722,14 @@
                             :template-id        6
                             :description        "Tehdään varsinainen päätös, omistaja vastasi kuulemiskirjeeseen"
                             :type-specific-data {:fine                     857
-                                                 :recipient-answered       true
-                                                 :answer-commentary-fi     "Yritykseni on niin iso, ettei minun tarvitse välittää tällaisista asioista"
-                                                 :answer-commentary-sv     "Mitt företag är så stort att jag inte behöver bry mig om sådana saker"
-                                                 :statement-fi             "Vastaus oli väärä, joten saat isot sakot."
-                                                 :statement-sv             "Svaret var fel, så du får stora böter."
-                                                 :osapuoli-specific-data   [{:osapuoli-id        osapuoli-id
-                                                                             :hallinto-oikeus-id 5
-                                                                             :document           true}]
+                                                 :osapuoli-specific-data   [{:osapuoli-id          osapuoli-id
+                                                                             :hallinto-oikeus-id   5
+                                                                             :document             true
+                                                                             :recipient-answered   true
+                                                                             :answer-commentary-fi "Yritykseni on niin iso, ettei minun tarvitse välittää tällaisista asioista"
+                                                                             :answer-commentary-sv "Mitt företag är så stort att jag inte behöver bry mig om sådana saker"
+                                                                             :statement-fi         "Vastaus oli väärä, joten saat isot sakot."
+                                                                             :statement-sv         "Svaret var fel, så du får stora böter."}]
                                                  :department-head-title-fi "Titteli"
                                                  :department-head-title-sv "Tittel"
                                                  :department-head-name     "Nimi"}}

--- a/etp-backend/src/test/resources/documents/kaskypaatos-varsinainen-paatos-yksityishenkilo.html
+++ b/etp-backend/src/test/resources/documents/kaskypaatos-varsinainen-paatos-yksityishenkilo.html
@@ -395,6 +395,7 @@
 
 <p class="respect-new-lines">Tämän kerran annetaan anteeksi, kun hän ei tiennyt.</p>
 
+
 <h2>Sovelletut oikeusohjeet</h2>
 
 <ul>
@@ -531,6 +532,7 @@
 <h3>Ställningstagande till bemötandet</h3>
 
 <p class="respect-new-lines">Han vet inte. Vi förlotar.</p>
+
 
 <h2>Tillämpliga rättsnormer</h2>
 

--- a/etp-backend/src/test/resources/documents/kaskypaatos-varsinainen-paatos-yritys.html
+++ b/etp-backend/src/test/resources/documents/kaskypaatos-varsinainen-paatos-yritys.html
@@ -357,7 +357,7 @@
     mielipiteensä asiasta sekä antaa selityksensä sellaisista vaatimuksista ja selvityksistä, jotka saattavat
     vaikuttaa asian ratkaisuun. Kuulemiskirjeessä ARA kertoi, että uhkasakon määrä on arviolta 9000 euroa.</p>
 
-<p class="respect-new-lines">Asianosainen ei vastannut kuulemiskirjeeseen. Yritys ei ollut tavoitettavissa ollenkaan asian tiimoilta.</p>
+<p class="respect-new-lines">Asianosainen ei vastannut kuulemiskirjeeseen.</p>
 
 <h2>Päätöksen perustelut</h2>
 
@@ -392,9 +392,7 @@
     mukaisena viimesijaisena keinona antaa käskypäätöksen, jolla rakennuksen omistaja velvoitetaan hankkimaan
     energiatodistus. Käskyä voidaan tehostaa uhkasakolla, josta säädetään uhkasakkolaissa.</p>
 
-<h3>Kannanotto vastineeseen</h3>
 
-<p class="respect-new-lines">Yritys tuomitaan sakkoihin.</p>
 
 <h2>Sovelletut oikeusohjeet</h2>
 
@@ -486,7 +484,7 @@
 
 <p>    
     Yritysomistaja
-    <span class="respect-new-lines">svarade inte på brevet om hörande. Företaget var inte nåbar alls angående ärendet.</span></p>
+    <span class="respect-new-lines">svarade inte på brevet om hörande.</span></p>
 
 <h2>Motivering av beslutet</h2>
 
@@ -529,9 +527,7 @@
     med 24 § i lagen om energicertifikat meddela ett beslut genom vilket byggnadens ägare åläggs att skaffa ett
     energicertifikat. Ordern kan förenas med vite enligt viteslagen. </p>
 
-<h3>Ställningstagande till bemötandet</h3>
 
-<p class="respect-new-lines">Företaget döms till böter.</p>
 
 <h2>Tillämpliga rättsnormer</h2>
 

--- a/etp-db/src/main/sql/migration/repeatable/vk_template/r-vk-template-kaskypaatos-varsinainen-paatos.sql
+++ b/etp-db/src/main/sql/migration/repeatable/vk_template/r-vk-template-kaskypaatos-varsinainen-paatos.sql
@@ -103,9 +103,13 @@ values (6, 'Käskypäätös / varsinainen päätös', 'Käskypäätös / varsina
     mukaisena viimesijaisena keinona antaa käskypäätöksen, jolla rakennuksen omistaja velvoitetaan hankkimaan
     energiatodistus. Käskyä voidaan tehostaa uhkasakolla, josta säädetään uhkasakkolaissa.</p>
 
+{{#tyyppikohtaiset-tiedot}}
+{{#recipient-answered}}
 <h3>Kannanotto vastineeseen</h3>
 
-<p class="respect-new-lines">{{#tyyppikohtaiset-tiedot}}{{statement-fi}}{{/tyyppikohtaiset-tiedot}}</p>
+<p class="respect-new-lines">{{statement-fi}}</p>
+{{/recipient-answered}}
+{{/tyyppikohtaiset-tiedot}}
 
 <h2>Sovelletut oikeusohjeet</h2>
 
@@ -291,9 +295,13 @@ values (6, 'Käskypäätös / varsinainen päätös', 'Käskypäätös / varsina
     med 24 § i lagen om energicertifikat meddela ett beslut genom vilket byggnadens ägare åläggs att skaffa ett
     energicertifikat. Ordern kan förenas med vite enligt viteslagen. </p>
 
+{{#tyyppikohtaiset-tiedot}}
+{{#recipient-answered}}
 <h3>Ställningstagande till bemötandet</h3>
 
-<p class="respect-new-lines">{{#tyyppikohtaiset-tiedot}}{{statement-sv}}{{/tyyppikohtaiset-tiedot}}</p>
+<p class="respect-new-lines">{{statement-sv}}</p>
+{{/recipient-answered}}
+{{/tyyppikohtaiset-tiedot}}
 
 <h2>Tillämpliga rättsnormer</h2>
 


### PR DESCRIPTION
Move answer-commentary-fi, answer-commentary-sv, statement-fi, statement-sv and recipient-answered under osapuoli-specific-data in KaskyPaatosVarsinainenPaatosData schema

- Do not render Kannanotto vastineeseen heading and the statement in the document if the recipient didn't answer
- Stricter schemas related to those fields with conditional schemas