### PR TITLE
Move palveluväylä API to routes root and version it

### DIFF
--- a/etp-backend/src/main/clj/solita/etp/api/palveluvayla.clj
+++ b/etp-backend/src/main/clj/solita/etp/api/palveluvayla.clj
@@ -15,7 +15,7 @@
            (reverse)
            (map first)))
 
-(def routes ["/energiatodistukset"
+(def routes ["/v1/energiatodistukset"
              ["/pdf/:id"
               ["" {:get {:summary    "Hae PDF-muotoinen energiatodistus tunnuksen id:llä"
                          :parameters {:path   {:id schema.common/Key}

--- a/etp-backend/src/main/clj/solita/etp/handler.clj
+++ b/etp-backend/src/main/clj/solita/etp/handler.clj
@@ -120,58 +120,59 @@
                        :body   headers})}}]])
 
 (def routes
-  ["/api" {:middleware [[header-middleware/wrap-default-cache]
-                        [header-middleware/wrap-default-content-type]]}
-   system-routes
-   ["/public" {:middleware [[security/wrap-db-application-name]]}
-    (concat (tag "Laatijat Public API" laatija-api/public-routes)
-            (tag "Geo Public API" geo-api/routes)
-            (tag "Energiatodistus Public API"
-                 energiatodistus-api/public-routes)
-            (tag "Tilastointi Public API"
-                 statistics-api/routes))]
-   ["/private" {:middleware [[header-middleware/wrap-disable-cache]
-                             [security/wrap-jwt-payloads]
-                             [security/wrap-whoami-from-jwt-payloads]
-                             [security/wrap-access]
-                             [security/wrap-db-application-name]]}
-    (concat (tag "Käyttäjä API" kayttaja-api/routes)
-            (tag "Yritys API" yritys-api/routes)
-            (tag "Laatijat Private API" laatija-api/private-routes)
-            (tag "Geo Private API" geo-api/routes)
-            (tag "Energiatodistus API" energiatodistus-api/private-routes)
-            (tag "Oikeellisuuden valvonta API" valvonta-oikeellisuus-api/routes)
-            (tag "Käytönvalvonta API" valvonta-kaytto-api/routes)
-            (tag "Valvonta API" valvonta-api/routes)
-            (tag "Viesti API" viesti-api/routes)
-            (tag "Sivu API" sivu-api/routes)
-            (tag "Tilastointi API" statistics-api/routes))]
-   ["/external" {:middleware [[security/wrap-whoami-from-basic-auth
-                               "Access to external API"]
+  ["" {:middleware [[header-middleware/wrap-default-cache]
+                 [header-middleware/wrap-default-content-type]]}
+   ["/api"
+    system-routes
+    ["/public" {:middleware [[security/wrap-db-application-name]]}
+     (concat (tag "Laatijat Public API" laatija-api/public-routes)
+             (tag "Geo Public API" geo-api/routes)
+             (tag "Energiatodistus Public API"
+                  energiatodistus-api/public-routes)
+             (tag "Tilastointi Public API"
+                  statistics-api/routes))]
+    ["/private" {:middleware [[header-middleware/wrap-disable-cache]
+                              [security/wrap-jwt-payloads]
+                              [security/wrap-whoami-from-jwt-payloads]
                               [security/wrap-access]
                               [security/wrap-db-application-name]]}
-    (concat (tag "Energiatodistus API" energiatodistus-api/external-routes)
-            (tag "Aineisto API" aineisto-api/external-routes))]
-   ["/signed" {:middleware [(if (every? (comp not empty?)
-                                        [config/public-index-url
-                                         config/url-signing-public-key])
-                              ;; Parameters for checking the signature are available,
-                              ;; so make use of them
-                              [security/wrap-whoami-from-signed
-                               config/public-index-url
-                               {:key-pair-id config/url-signing-key-id
-                                :public-key  (signed-url/pem-string->public-key
-                                               config/url-signing-public-key)}]
-                              ;; Otherwise, assume that the reverse
-                              ;; proxies on front of the backend
-                              ;; service have verified the signature.
-                              [security/wrap-whoami-assume-verified-signature])
-                            [security/wrap-access]
-                            [security/wrap-db-application-name]]}
-    (concat (tag "Aineisto API" aineisto-api/signed-routes))]
-   ["/internal"
-    (concat (tag "Laskutus API" laskutus-api/routes)
-            (tag "Laatija Internal API" laatija-api/internal-routes))]
+     (concat (tag "Käyttäjä API" kayttaja-api/routes)
+             (tag "Yritys API" yritys-api/routes)
+             (tag "Laatijat Private API" laatija-api/private-routes)
+             (tag "Geo Private API" geo-api/routes)
+             (tag "Energiatodistus API" energiatodistus-api/private-routes)
+             (tag "Oikeellisuuden valvonta API" valvonta-oikeellisuus-api/routes)
+             (tag "Käytönvalvonta API" valvonta-kaytto-api/routes)
+             (tag "Valvonta API" valvonta-api/routes)
+             (tag "Viesti API" viesti-api/routes)
+             (tag "Sivu API" sivu-api/routes)
+             (tag "Tilastointi API" statistics-api/routes))]
+    ["/external" {:middleware [[security/wrap-whoami-from-basic-auth
+                                "Access to external API"]
+                               [security/wrap-access]
+                               [security/wrap-db-application-name]]}
+     (concat (tag "Energiatodistus API" energiatodistus-api/external-routes)
+             (tag "Aineisto API" aineisto-api/external-routes))]
+    ["/signed" {:middleware [(if (every? (comp not empty?)
+                                         [config/public-index-url
+                                          config/url-signing-public-key])
+                               ;; Parameters for checking the signature are available,
+                               ;; so make use of them
+                               [security/wrap-whoami-from-signed
+                                config/public-index-url
+                                {:key-pair-id config/url-signing-key-id
+                                 :public-key  (signed-url/pem-string->public-key
+                                                config/url-signing-public-key)}]
+                               ;; Otherwise, assume that the reverse
+                               ;; proxies on front of the backend
+                               ;; service have verified the signature.
+                               [security/wrap-whoami-assume-verified-signature])
+                             [security/wrap-access]
+                             [security/wrap-db-application-name]]}
+     (concat (tag "Aineisto API" aineisto-api/signed-routes))]
+    ["/internal"
+     (concat (tag "Laskutus API" laskutus-api/routes)
+             (tag "Laatija Internal API" laatija-api/internal-routes))]]
    (when config/allow-palveluvayla-api
      ["/palveluvayla" ["/openapi.json" {:get {:no-doc  true :openapi {:info {:title "Energiatodistuspalvelu API" :description "Hae energiatodistuksia pdf tai json muodoissa"}
                                                                       :id   "Palveluväylä"}

--- a/etp-backend/src/test/clj/solita/etp/api/palveluvayla_test.clj
+++ b/etp-backend/src/test/clj/solita/etp/api/palveluvayla_test.clj
@@ -13,7 +13,7 @@
 
 (t/use-fixtures :each ts/fixture)
 
-(def palveluvayla-basepath "/api/palveluvayla/energiatodistukset")
+(def palveluvayla-basepath "/palveluvayla/v1/energiatodistukset")
 
 (t/deftest test-palveluvayla-api
   (let [; Add laatija


### PR DESCRIPTION
Because of technical reasons in the sidecar (liityntäpalvelin), we need have the palveluväylä API start without dashes.  Solved the issue by moving the API to server root.

(Technical reason: Our documentation is the autogenerated OpenAPI specification. The relative URLs there are from the server root, previously beginning with /api/palveluväylä/. In the sidecar configuration, our service is defined as basepath service, with the url http://instances.core-public.local:8080/api/palveluvayla. It's defined that way, so that the users cannot access APIs other than those under /api/palveluvayla. However the url that users use, is in the form of https://sidecar/r1/organisation/identifier/codes/service-code/url-from-openapi-specification. The service code is defined on the sidecar, and cannot contain slashes. If we use palveluvayla as the service code, and as the root of our palveluväylä API, the urls that are used to connect our service using palveluväylä match those that are defined in the OpenAPI specification.)

Version the palveluväylä API so we can make breaking changes in the future.